### PR TITLE
Move graphviz2png to argparse and fix a variable unassigned before use

### DIFF
--- a/filters/graphviz/graphviz2png.py
+++ b/filters/graphviz/graphviz2png.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 import os, sys, subprocess
-from optparse import *
+import argparse
 
 __AUTHOR__ = "Gouichi Iisaka <iisaka51@gmail.com>"
-__VERSION__ = '1.1.4'
+__VERSION__ = '1.1.5'
 
 class EApp(Exception):
     '''Application specific exception.'''
@@ -72,39 +72,31 @@ LICENSE
         if not argv:
             argv = sys.argv
 
-        self.usage = '%prog [options] inputfile'
+        self.usage = '%(prog)s [options] infile'
         self.version = 'Version: %s\n' % __VERSION__
         self.version += 'Copyright(c) 2008-2009: %s\n' % __AUTHOR__
 
-        self.option_list = [
-            Option("-o", "--outfile", action="store",
+        self.parser = argparse.ArgumentParser(usage=self.usage)
+        self.parser.add_argument("-o", "--outfile", action="store",
                 dest="outfile",
-                help="Output file"),
-            Option("-L", "--layout", action="store",
-                dest="layout", default="dot", type="choice",
+                help="Output file")
+        self.parser.add_argument("-L", "--layout", action="store",
+                dest="layout", default="dot",
                 choices=['dot','neato','twopi','circo','fdp'],
-                help="Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>"),
-            Option("-F", "--format", action="store",
-                dest="format", default="png", type="choice",
+                help="Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>")
+        self.parser.add_argument("-F", "--format", action="store",
+                dest="format", default="png",
                 choices=supported_formats,
-                help="Format type. FORMAT=<" + "|".join(supported_formats) + ">"),
-            Option("--debug", action="store_true",
+                help="Format type. FORMAT=<" + "|".join(supported_formats) + ">")
+        self.parser.add_argument("--debug", action="store_true",
                 dest="do_debug",
-                help=SUPPRESS_HELP),
-            Option("-v", "--verbose", action="store_true",
+                help=argparse.SUPPRESS)
+        self.parser.add_argument("-v", "--verbose", action="store_true",
                 dest="do_verbose", default=False,
-                help="verbose output"),
-            ]
-
-        self.parser = OptionParser( usage=self.usage, version=self.version,
-                                    option_list=self.option_list)
-        (self.options, self.args) = self.parser.parse_args()
-
-        if len(self.args) != 1:
-            self.parser.print_help()
-            sys.exit(1)
-
-        self.options.infile = self.args[0]
+                help="verbose output")
+        self.parser.add_argument("infile", action="store", help="Input file")
+        self.parser.add_argument('--version', action='version', version=self.version)
+        self.options = self.parser.parse_args()
 
     def systemcmd(self, cmd):
         if self.options.do_verbose:
@@ -142,6 +134,7 @@ LICENSE
         if self.options.format == '':
             self.options.format = 'png'
 
+        infile = self.options.infile
         if self.options.infile == '-':
             if self.options.outfile is None:
                 sys.stderr.write('OUTFILE must be specified')

--- a/filters/graphviz/graphviz2png.py
+++ b/filters/graphviz/graphviz2png.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
-import os, sys, subprocess
+import os
+import sys
+import subprocess
 import argparse
 
 __AUTHOR__ = "Gouichi Iisaka <iisaka51@gmail.com>"
@@ -77,23 +79,15 @@ LICENSE
         self.version += 'Copyright(c) 2008-2009: %s\n' % __AUTHOR__
 
         self.parser = argparse.ArgumentParser(usage=self.usage)
-        self.parser.add_argument("-o", "--outfile", action="store",
-                dest="outfile",
-                help="Output file")
-        self.parser.add_argument("-L", "--layout", action="store",
-                dest="layout", default="dot",
-                choices=['dot','neato','twopi','circo','fdp'],
-                help="Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>")
-        self.parser.add_argument("-F", "--format", action="store",
-                dest="format", default="png",
-                choices=supported_formats,
-                help="Format type. FORMAT=<" + "|".join(supported_formats) + ">")
-        self.parser.add_argument("--debug", action="store_true",
-                dest="do_debug",
-                help=argparse.SUPPRESS)
-        self.parser.add_argument("-v", "--verbose", action="store_true",
-                dest="do_verbose", default=False,
-                help="verbose output")
+        self.parser.add_argument("-o", "--outfile", action="store", dest="outfile", help="Output file")
+        self.parser.add_argument("-L", "--layout", action="store", dest="layout", default="dot",
+                                 choices=['dot', 'neato', 'twopi', 'circo', 'fdp'],
+                                 help="Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>")
+        self.parser.add_argument("-F", "--format", action="store", dest="format", default="png",
+                                 choices=supported_formats,
+                                 help="Format type. FORMAT=<" + "|".join(supported_formats) + ">")
+        self.parser.add_argument("--debug", action="store_true", dest="do_debug", help=argparse.SUPPRESS)
+        self.parser.add_argument("-v", "--verbose", action="store_true", dest="do_verbose", default=False, help="verbose output")
         self.parser.add_argument("infile", action="store", help="Input file")
         self.parser.add_argument('--version', action='version', version=self.version)
         self.options = self.parser.parse_args()
@@ -117,12 +111,10 @@ LICENSE
         if not os.path.isdir(outdir):
             raise EApp('directory does not exist: %s' % outdir)
 
-        basefile = os.path.splitext(outfile)[0]
         saved_cwd = os.getcwd()
         os.chdir(outdir)
         try:
-            cmd = '%s -T%s "%s" > "%s"' % (
-                  self.options.layout, self.options.format, infile, outfile)
+            cmd = '%s -T%s "%s" > "%s"' % (self.options.layout, self.options.format, infile, outfile)
             self.systemcmd(cmd)
         finally:
             os.chdir(saved_cwd)

--- a/filters/graphviz/graphviz2png.py
+++ b/filters/graphviz/graphviz2png.py
@@ -81,11 +81,9 @@ LICENSE
         self.parser = argparse.ArgumentParser(usage=self.usage)
         self.parser.add_argument("-o", "--outfile", action="store", dest="outfile", help="Output file")
         self.parser.add_argument("-L", "--layout", action="store", dest="layout", default="dot",
-                                 choices=['dot', 'neato', 'twopi', 'circo', 'fdp'],
-                                 help="Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>")
+                                 choices=['dot', 'neato', 'twopi', 'circo', 'fdp'], help="Layout type")
         self.parser.add_argument("-F", "--format", action="store", dest="format", default="png",
-                                 choices=supported_formats,
-                                 help="Format type. FORMAT=<" + "|".join(supported_formats) + ">")
+                                 choices=supported_formats, help="Format type")
         self.parser.add_argument("--debug", action="store_true", dest="do_debug", help=argparse.SUPPRESS)
         self.parser.add_argument("-v", "--verbose", action="store_true", dest="do_verbose", default=False, help="verbose output")
         self.parser.add_argument("infile", action="store", help="Input file")


### PR DESCRIPTION
Moving `graphviz2png.py` from optparse to argparse as mentioned in #4 

I had to fix the following issue when generating from a file and not from the input directly (which is the change in the `run` function) to make it work:
```
Traceback (most recent call last):                                
  File "filters/graphviz/graphviz2png.py", line 161, in <module>                   
    app.run()                                                                                      
  File "filters/graphviz/graphviz2png.py", line 145, in run                                                                                                    
    if not os.path.isfile(infile):
UnboundLocalError: local variable 'infile' referenced before assignment
```

Tested the generation via input string:
```
echo "digraph G {Hello->World}" | python3 filters/graphviz/graphviz2png.py -o hello_world.png -
```
Tested the generation from a file:
```
echo "digraph G {Hello->World}" > hello_world.gra
python3 filters/graphviz/graphviz2png.py -o hello_world.png hello_world.gra
```

Tested the help display:
```
$ python3 filters/graphviz/graphviz2png.py -h
usage: graphviz2png.py [options] infile

positional arguments:
  infile                Input file

optional arguments:
  -h, --help            show this help message and exit
  -o OUTFILE, --outfile OUTFILE
                        Output file
  -L {dot,neato,twopi,circo,fdp}, --layout {dot,neato,twopi,circo,fdp}
                        Layout type. LAYOUT=<dot|neato|twopi|circo|fdp>
  -F {canon,cmap,cmapx,cmapx_np,dot,dot_json,eps,fig,gd,gd2,gif,gv,imap,imap_np,ismap,jpe,jpeg,jpg,json,json0,mp,pdf,pic,plain,plain-ext,png,pov,ps,ps2,svg,svgz,tk,vml,vmlz,vrml,wbmp,x11,xdot,xdot1.2,xdot1.4,xdot_json,xlib}, --format {canon,cmap,cmapx,cmapx_np,dot,dot_json,eps,fig,gd,gd2,gif,gv,imap,imap_np,ismap,jpe,jpeg,jpg,json,json0,mp,pdf,pic,plain,plain-ext,png,pov,ps,ps2,svg,svgz,tk,vml,vmlz,vrml,wbmp,x11,xdot,xdot1.2,xdot1.4,xdot_json,xlib}
                        Format type. FORMAT=<canon|cmap|cmapx|cmapx_np|dot|dot
                        _json|eps|fig|gd|gd2|gif|gv|imap|imap_np|ismap|jpe|jpe
                        g|jpg|json|json0|mp|pdf|pic|plain|plain-ext|png|pov|ps
                        |ps2|svg|svgz|tk|vml|vmlz|vrml|wbmp|x11|xdot|xdot1.2|x
                        dot1.4|xdot_json|xlib>
  -v, --verbose         verbose output
  --version             show program's version number and exit
```

All work great.