### PR TITLE
Remove deprecated unicode option on regex

### DIFF
--- a/asciidoc.conf
+++ b/asciidoc.conf
@@ -220,34 +220,34 @@ template::[partintroblock]
 # (?s) re flag for line spanning.
 
 # Macros using default syntax.
-(?su)(?<!\w)[\\]?(?P<name>http|https|ftp|file|irc|mailto|callto|image|link|anchor|xref|indexterm|indexterm2):(?P<target>\S*?)\[(?P<attrlist>.*?)(?<!\\)\]=
+(?s)(?<!\w)[\\]?(?P<name>http|https|ftp|file|irc|mailto|callto|image|link|anchor|xref|indexterm|indexterm2):(?P<target>\S*?)\[(?P<attrlist>.*?)(?<!\\)\]=
 
 # These URL types don't require any special attribute list formatting.
-(?su)(?<!\S)[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
+(?s)(?<!\S)[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
 # Allow a leading parenthesis and square bracket.
-(?su)(?<\=[([])[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
+(?s)(?<\=[([])[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
 # Allow <> brackets.
-(?su)[\\]?&lt;(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])&gt;=
+(?s)[\\]?&lt;(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])&gt;=
 
 # Email addresses don't require special attribute list formatting.
 # The before ">: and after "< character exclusions stop multiple substitution.
-(?su)(?<![">:\w._/-])[\\]?(?P<target>\w[\w._-]*@[\w._-]*\w)(?!["<\w_-])=mailto
+(?s)(?<![">:\w._/-])[\\]?(?P<target>\w[\w._-]*@[\w._-]*\w)(?!["<\w_-])=mailto
 
 # Allow footnote macros hard up against the preceding word so the footnote mark
 # can be placed against the noted text without an intervening space
 # (http://groups.google.com/group/asciidoc/browse_frm/thread/e1dcb7ee0efc17b5).
-(?su)[\\]?(?P<name>footnote|footnoteref):(?P<target>\S*?)\[(?P<attrlist>.*?)(?<!\\)\]=
+(?s)[\\]?(?P<name>footnote|footnoteref):(?P<target>\S*?)\[(?P<attrlist>.*?)(?<!\\)\]=
 
 # Anchor: [[[id]]]. Bibliographic anchor.
-(?su)[\\]?\[\[\[(?P<attrlist>[\w_:][\w_:.-]*?)\]\]\]=anchor3
+(?s)[\\]?\[\[\[(?P<attrlist>[\w_:][\w_:.-]*?)\]\]\]=anchor3
 # Anchor: [[id,xreflabel]]
-(?su)[\\]?\[\[(?P<attrlist>[\w"_:].*?)\]\]=anchor2
+(?s)[\\]?\[\[(?P<attrlist>[\w"_:].*?)\]\]=anchor2
 # Link: <<id,text>>
-(?su)[\\]?&lt;&lt;(?P<attrlist>[\w"_:].*?)&gt;&gt;=xref2
+(?s)[\\]?&lt;&lt;(?P<attrlist>[\w"_:].*?)&gt;&gt;=xref2
 
 ifdef::asciidoc7compatible[]
 # Index term: ++primary,secondary,tertiary++
-(?su)(?<!\S)[\\]?\+\+(?P<attrlist>[^+].*?)\+\+(?!\+)=indexterm
+(?s)(?<!\S)[\\]?\+\+(?P<attrlist>[^+].*?)\+\+(?!\+)=indexterm
 # Index term: +primary+
 # Follows ++...++ macro otherwise it will match them.
 (?<!\S)[\\]?\+(?P<attrlist>[^\s\+][^+].*?)\+(?!\+)=indexterm2
@@ -255,7 +255,7 @@ endif::asciidoc7compatible[]
 
 ifndef::asciidoc7compatible[]
 # Index term: (((primary,secondary,tertiary)))
-(?su)(?<!\()[\\]?\(\(\((?P<attrlist>[^(].*?)\)\)\)(?!\))=indexterm
+(?s)(?<!\()[\\]?\(\(\((?P<attrlist>[^(].*?)\)\)\)(?!\))=indexterm
 # Index term: ((primary))
 # Follows (((...))) macro otherwise it will match them.
 (?<!\()[\\]?\(\((?P<attrlist>[^\s\(].*?)\)\)(?!\))=indexterm2
@@ -265,24 +265,24 @@ endif::asciidoc7compatible[]
 [\\]?&lt;(?P<index>\d+)&gt;=callout
 
 # Passthrough macros.
-(?su)[\\]?(?P<name>pass):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[]
+(?s)[\\]?(?P<name>pass):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[]
 
 # Triple-plus and double-dollar inline passthroughs.
-(?su)[\\]?\+\+\+(?P<passtext>.*?)\+\+\+=pass[]
-(?su)[\\]?\$\$(?P<passtext>.*?)\$\$=pass[specialcharacters]
+(?s)[\\]?\+\+\+(?P<passtext>.*?)\+\+\+=pass[]
+(?s)[\\]?\$\$(?P<passtext>.*?)\$\$=pass[specialcharacters]
 
 # Inline literal.
 ifndef::no-inline-literal[]
-(?su)(?<![`\w])([\\]?`(?P<passtext>[^`\s]|[^`\s].*?\S)`)(?![`\w])=literal[specialcharacters]
+(?s)(?<![`\w])([\\]?`(?P<passtext>[^`\s]|[^`\s].*?\S)`)(?![`\w])=literal[specialcharacters]
 endif::no-inline-literal[]
 
 # Inline comment.
-(?mu)^[\\]?//(?P<passtext>[^/].*|)$=comment[specialcharacters]
+(?m)^[\\]?//(?P<passtext>[^/].*|)$=comment[specialcharacters]
 
 # Default (catchall) inline macro is not implemented so there is no ambiguity
 # with previous definition that could result in double substitution of escaped
 # references.
-#(?su)[\\]?(?P<name>\w(\w|-)*?):(?P<target>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=
+#(?s)[\\]?(?P<name>\w(\w|-)*?):(?P<target>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=
 
 #-------------
 # Block macros

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -552,14 +552,14 @@ def subs_quotes(text):
         if tag[0] == '#':
             tag = tag[1:]
             # Unconstrained quotes can appear anywhere.
-            reo = re.compile(r'(?msu)(^|.)(\[(?P<attrlist>[^[\]]+?)\])?' +
+            reo = re.compile(r'(?ms)(^|.)(\[(?P<attrlist>[^[\]]+?)\])?' +
                              r'(?:' + re.escape(lq) + r')' +
                              r'(?P<content>.+?)(?:' + re.escape(rq) + r')')
         else:
             # The text within constrained quotes must be bounded by white space.
             # Non-word (\W) characters are allowed at boundaries to accommodate
             # enveloping quotes and punctuation e.g. a='x', ('x'), 'x', ['x'].
-            reo = re.compile(r'(?msu)(^|[^\w;:}])(\[(?P<attrlist>[^[\]]+?)\])?' +
+            reo = re.compile(r'(?ms)(^|[^\w;:}])(\[(?P<attrlist>[^[\]]+?)\])?' +
                              r'(?:' + re.escape(lq) + r')' +
                              r'(?P<content>\S|\S.*?\S)(?:' + re.escape(rq) + r')(?=\W|$)')
         pos = 0
@@ -1035,7 +1035,7 @@ def subs_attrs(lines, dictionary=None):
         line = line.replace('\\}', '}\\')
         # Expand simple attributes ({name}).
         # Nested attributes not allowed.
-        reo = re.compile(r'(?su)\{(?P<name>[^\\\W][-\w]*?)\}(?!\\)')
+        reo = re.compile(r'(?s)\{(?P<name>[^\\\W][-\w]*?)\}(?!\\)')
         pos = 0
         while True:
             mo = reo.search(line, pos)
@@ -1050,11 +1050,11 @@ def subs_attrs(lines, dictionary=None):
                 pos = mo.start() + len(s)
         # Expand conditional attributes.
         # Single name -- higher precedence.
-        reo1 = re.compile(r'(?su)\{(?P<name>[^\\\W][-\w]*?)'
+        reo1 = re.compile(r'(?s)\{(?P<name>[^\\\W][-\w]*?)'
                           r'(?P<op>\=|\?|!|#|%|@|\$)'
                           r'(?P<value>.*?)\}(?!\\)')
         # Multiple names (n1,n2,... or n1+n2+...) -- lower precedence.
-        reo2 = re.compile(r'(?su)\{(?P<name>[^\\\W][-\w' + OR + AND + r']*?)'
+        reo2 = re.compile(r'(?s)\{(?P<name>[^\\\W][-\w' + OR + AND + r']*?)'
                           r'(?P<op>\=|\?|!|#|%|@|\$)'
                           r'(?P<value>.*?)\}(?!\\)')
         for reo in [reo1, reo2]:
@@ -1161,14 +1161,14 @@ def subs_attrs(lines, dictionary=None):
                 line = line[:mo.start()] + s + line[end:]
                 pos = mo.start() + len(s)
         # Drop line if it contains  unsubstituted {name} references.
-        skipped = re.search(r'(?su)\{[^\\\W][-\w]*?\}(?!\\)', line)
+        skipped = re.search(r'(?s)\{[^\\\W][-\w]*?\}(?!\\)', line)
         if skipped:
             trace('dropped line', line)
             continue
         # Expand system attributes (eval has precedence).
         reos = [
-            re.compile(r'(?su)\{(?P<action>eval):(?P<expr>.*?)\}(?!\\)'),
-            re.compile(r'(?su)\{(?P<action>[^\\\W][-\w]*?):(?P<expr>.*?)\}(?!\\)'),
+            re.compile(r'(?s)\{(?P<action>eval):(?P<expr>.*?)\}(?!\\)'),
+            re.compile(r'(?s)\{(?P<action>[^\\\W][-\w]*?):(?P<expr>.*?)\}(?!\\)'),
         ]
         skipped = False
         for reo in reos:
@@ -3645,7 +3645,7 @@ class Table(AbstractBlock):
             else:
                 self.error('illegal table cell operator')
         text = '\n'.join(text)
-        separator = '(?msu)' + self.parameters.separator
+        separator = '(?ms)' + self.parameters.separator
         format = self.parameters.format
         start = 0
         span = None

--- a/docbook45.conf
+++ b/docbook45.conf
@@ -46,7 +46,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 
 [macros]
 # math macros.
-(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
+(?s)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
 ^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
 
 [latexmath-inlinemacro]

--- a/docbook5.conf
+++ b/docbook5.conf
@@ -44,8 +44,8 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 
 [macros]
 # math macros.
-(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
-(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
+(?s)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
+^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
 
 [latexmath-inlinemacro]
 <inlineequation>

--- a/html5.conf
+++ b/html5.conf
@@ -39,9 +39,9 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 ^(?P<name>audio|video)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
 # math macros.
 # Special characters are escaped in HTML math markup.
-(?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
+(?s)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
 ^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
-(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
+(?s)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
 ^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]

--- a/latex.conf
+++ b/latex.conf
@@ -63,7 +63,7 @@ _=\_{}
 [\\]?<(?P<index>\d+)>=callout
 
 # Link: <<id,text>>
-(?su)[\\]?<<(?P<attrlist>[\w"].*?)>>=xref2
+(?s)[\\]?<<(?P<attrlist>[\w"].*?)>>=xref2
 
 [replacements]
 

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -38,9 +38,9 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 [macros]
 # math macros.
 # Special characters are escaped in HTML math markup.
-(?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
+(?s)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
 ^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
-(?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
+(?s)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
 ^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]


### PR DESCRIPTION
Remove some forgotten `(?u)` in regex as now we are in python3, keeping them is useless.
Most of them had already been removed anyway. That's just a cleanup.