### PR TITLE
README: Update "Obtaining" for under-development asciidoc-py3

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -21,9 +21,10 @@ official Python website http://www.python.org.
 
 Obtaining AsciiDoc
 ------------------
-Documentation and installation instructions are on the AsciiDoc
-website http://asciidoc.org/
-
+AsciiDoc's Python 3 port is currently under development. To obtain AsciiDoc,
+download a copy of the repo from the GitHub project at
+https://github.com/asciidoc/asciidoc-py3 and follow the instructions in
+INSTALL.txt to build and install it.
 
 Tools
 -----


### PR DESCRIPTION
The README's current "Obtaining AsciiDoc" section text points to asciidoc.org, which describes the old Python 2 version. This PR updates the text to point to the under-development asciidoc-py3 project.

Open to suggestions for improving the wording here.