### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-dist: trusty
-sudo: true
 language: python
 python:
   - 3.4
   - 3.5
   - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
   - sudo apt-get update -yq2
   - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
+dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 python:
   - 3.4
   - 3.5
   - 3.6
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+  - 3.7
+      
 install:
   - sudo apt-get update -yq2
   - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base


### PR DESCRIPTION
Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).