### PR TITLE
Update MathJax CDN link

### DIFF
--- a/html5.conf
+++ b/html5.conf
@@ -637,7 +637,7 @@ ifdef::mathjax[]
       "HTML-CSS": { availableFonts: ["TeX"] }
     });
   </script>
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
 endif::mathjax[]
 {docinfo1,docinfo2#}{include:{docdir}/docinfo.html}
 {docinfo,docinfo2#}{include:{docdir}/{docname}-docinfo.html}

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -634,7 +634,7 @@ ifdef::mathjax[]
       "HTML-CSS": { availableFonts: ["TeX"] }
     });
   </script>
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
 endif::mathjax[]
 {docinfo1,docinfo2#}{include:{docdir}/docinfo.html}
 {docinfo,docinfo2#}{include:{docdir}/{docname}-docinfo.html}


### PR DESCRIPTION
The old link (https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML) was retired and is recommended to be replaced with a link to cloudflare's cdnjs.