### PR TITLE
Update Dockerfile to better allow using different python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,32 @@
-FROM ubuntu:18.04
+# You can specify a specific python version to use by doing
+# --build-arg PYTHON_VERSION=<version> on the build command,
+# This defaults to 3.6 if nothing is given.
+ARG PYTHON_VERSION=3.6
 
-RUN apt-get update && \
-    apt-get install -y python3 autoconf make wget unzip libxml2-utils xsltproc && \
-    apt-get install -y dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base docbook-xsl
+# These images are based off Debian Stretch (slim) using https://hub.docker.com/_/python/ as the "base"
+FROM python:${PYTHON_VERSION}-stretch
+
+# Install asciidoc dependencies
+# install the necessary stuff for asciidoc now that python has been built
+RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list && apt-get update && \
+    apt-get install -y --no-install-recommends \
+        autoconf \
+        docbook-xsl \
+        dvipng \
+        git \
+        graphviz \
+        imagemagick \
+        libxml2-utils \
+        make \
+        python3 \
+        source-highlight \
+        time \
+        texlive-latex-base \
+        unzip \
+        xsltproc \
+        && \
+    apt-get -t stretch-backports install -y --no-install-recommends lilypond && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . "/srv/asciidoc"
 WORKDIR "/srv/asciidoc"


### PR DESCRIPTION
This is a part of the work from #38 (which I didn't notice till now was closed after I messed up doing merges on my fork) and is necessary for carrying out #21. This makes it so that we can easily test on a range of python versions, but remain on the same base (Debian Stretch) so that we don't end up with different versions of the other dependencies of asciidoc (namely libpng/lilypond) which cause the tests to fail then.