### PR TITLE
Fix using number flag for testasciidoc.py

### DIFF
--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -416,7 +416,7 @@ if __name__ == '__main__':
     number = None
     backend = None
     if 'number' in args:
-        number = number
+        number = args.number
     if 'backend' in args:
         backend = args.backend
     if backend and backend not in BACKENDS:


### PR DESCRIPTION
Fixes using `--number` for `./tests/testasciidoc.py` to select a specific test.