### PR TITLE
Add in missing .css and .js files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include asciidoc/resources *.conf *.txt *.py *.png
+recursive-include asciidoc/resources *.conf *.txt *.py *.png *.js *.css


### PR DESCRIPTION
Missing some files in the MANIFEST.in file for the python3 packaging which causes it to not run properly.

Can be tested from https://test.pypi.org/project/asciidoc/