### PR TITLE
Drop python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 python:
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ AsciiDoc ChangeLog
 Version 9.0.0 (Unreleased)
 --------------------------
 .Additions and changes
-- Port asciidoc to run on Python 3.4+ (see https://github.com/asciidoc/asciidoc for the EOL Python 2 implementation)
+- Port asciidoc to run on Python 3.5+ (see https://github.com/asciidoc/asciidoc for the EOL Python 2 implementation)
 - Drop internal implementation of OrderedDict and use the standard library collections.OrderedDict instead
 - Implement Dockerfile for running asciidoc
 - Add Catalan translation

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,7 +1,7 @@
 AsciiDoc Installation
 =====================
 
-NOTE: The current version of AsciiDoc requires *Python 3.4 or later*
+NOTE: The current version of AsciiDoc requires *Python 3.5 or later*
 to run.  If you don't already have an up-to-date version of Python
 installed it can be downloaded from the official Python website
 http://www.python.org/.
@@ -17,7 +17,7 @@ Installing from the GitHub repository
 The AsciiDoc repository is hosted by https://github.com[GitHub].
 To browse the repository go to https://github.com/asciidoc/asciidoc-py3.
 You can install AsciiDoc from the repository if you don't have an up to
-date packaged version, or you want to get the latest version from the master 
+date packaged version, or you want to get the latest version from the master
 branch:
 
 - Make sure you have https://git-scm.com/[Git]
@@ -176,7 +176,7 @@ Prepackaged AsciiDoc installation
 The following platform-specific AsciiDoc-py3 packages are available:
 
 *Fedora Linux*::
-  AsciiDoc is included in Fedora Extras, which is available in 
+  AsciiDoc is included in Fedora Extras, which is available in
   the default Fedora installation. To install asciidoc, execute the
   following command:
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -14,7 +14,7 @@ SGML/XML markup) can be customized and extended by the user.
 Prerequisites
 -------------
 AsciiDoc is written in Python so you need a Python interpreter
-(version 3.4 or later) to execute asciidoc(1). Python is installed by
+(version 3.5 or later) to execute asciidoc(1). Python is installed by
 default in most Linux distributions.  You can download Python from the
 official Python website http://www.python.org.
 

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 # Used by asciidocapi.py #
 VERSION = '8.6.10'           # See CHANGELOG file for version history.
 
-MIN_PYTHON_VERSION = '3.4'  # Require this version of Python or better.
+MIN_PYTHON_VERSION = '3.5'  # Require this version of Python or better.
 
 # ---------------------------------------------------------------------------
 # Program constants.

--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -228,15 +228,10 @@ class AsciiDocAPI(object):
             # The import statement can only handle .py or .pyc files, have to
             # use importlib for scripts with other names.
             try:
-                # Remove use of imp when Python 3.4 support is dropped
-                if sys.version_info[1] < 5:
-                    import imp
-                    module = imp.load_source('asciidoc', self.cmd)
-                else:
-                    import importlib.util
-                    spec = importlib.util.spec_from_file_location('asciidoc', self.cmd)
-                    module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(module)
+                import importlib.util
+                spec = importlib.util.spec_from_file_location('asciidoc', self.cmd)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
                 self.asciidoc = module
             except ImportError:
                 raise AsciiDocError('failed to import ' + self.cmd)


### PR DESCRIPTION
Closes #64 

Drops 3.4 support as it was EOL back in March and it's recommended that one upgrade to 3.5+ to enjoy new features, bugfixes, etc.

This does lack some changes that'll be necessary for the repackage branch in setup.py