### PR TITLE
Add makefile target for spell checking

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -157,6 +157,24 @@ vers_update:
 		chmod +x $$f; \
 	done
 
+DOC_FILES = CHANGELOG.txt README.asciidoc BUGS.txt INSTALL.txt doc/a2x.1.txt \
+	 		doc/faq.txt doc/asciidocapi.txt doc/testasciidoc.txt \
+			doc/epub-notes.txt doc/publishing-ebooks-with-asciidoc.txt \
+			doc/source-highlight-filter.txt doc/slidy.txt doc/slidy-example.txt
+
+WEBSITE_FILES = examples/website/index.txt examples/website/README-website.txt examples/website/support.txt
+
+.PHONY: ${DOC_FILES}
+${DOC_FILES}:
+	aspell check -p ./doc/asciidoc.dict $@
+
+.PHONY: ${WEBSITE_FILES}
+${WEBSITE_FILES}:
+	aspell check -p ./examples/website/asciidoc-website.dict $@
+
+.PHONY: spell
+spell: ${DOC_FILES} ${WEBSITE_FILES} ; echo Spelling Checked
+
 build: fixconfpath $(manp)
 
 install: all $(PROGTARGETS) $(DATATARGETS) progsymlink

--- a/Makefile.in
+++ b/Makefile.in
@@ -172,8 +172,14 @@ ${DOC_FILES}:
 ${WEBSITE_FILES}:
 	aspell check -p ./examples/website/asciidoc-website.dict $@
 
+.PHONY: spell_doc
+doc_spell: ${DOC_FILES}
+
+.PHONY: spell_website
+website_spell: ${WEBSITE_FILES}
+
 .PHONY: spell
-spell: ${DOC_FILES} ${WEBSITE_FILES} ; echo Spelling Checked
+spell: spell_doc spell_website
 
 build: fixconfpath $(manp)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -179,7 +179,7 @@ doc_spell: ${DOC_FILES}
 website_spell: ${WEBSITE_FILES}
 
 .PHONY: spell
-spell: spell_doc spell_website
+spell: doc_spell website_spell
 
 build: fixconfpath $(manp)
 


### PR DESCRIPTION
Continued work on #44 / #83 in translating the *.aap targets to makefile targets.

This unifies the spell target in `doc/` and `examples/website/` to a top-level `make spell` with each also having their own target of `doc_spell` and `website_spell` to retain capacity of checking just one.