### PR TITLE
Add short version of args to testasciidoc

### DIFF
--- a/doc/testasciidoc.1.txt
+++ b/doc/testasciidoc.1.txt
@@ -24,8 +24,8 @@ COMMANDS
 The testasciidoc toolset has three different commands:
 
   testasciidoc list
-  testasciidoc run [--number NUMBER] [--backend BACKEND] [OPTIONS]
-  testasciidoc update [--number NUMBER] [--backend BACKEND] [OPTIONS]
+  testasciidoc run [-n, --number NUMBER] [-b, --backend BACKEND] [OPTIONS]
+  testasciidoc update [-n, --number NUMBER] [-b, --backend BACKEND] [OPTIONS]
 
 The commands perform as follows:
 

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -392,8 +392,8 @@ if __name__ == '__main__':
     subparsers.add_parser('list', help='List tests')
 
     options = ArgumentParser(add_help=False)
-    options.add_argument('--number', type=int, help='Test number to run')
-    options.add_argument('--backend', type=str, help='Backend to run')
+    options.add_argument('-n', '--number', type=int, help='Test number to run')
+    options.add_argument('-b', '--backend', type=str, help='Backend to run')
 
     subparsers.add_parser('run', help='Execute tests', parents=[options])
 


### PR DESCRIPTION
The idea is to be consistent overall by providing short versions for all our args (except for `--force` which is most of the time not shortened anyway) as there are some which have the short version.