### PR TITLE
asciidocapi: Fix crash  on load of the loader

### DIFF
--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -228,9 +228,11 @@ class AsciiDocAPI(object):
             # The import statement can only handle .py or .pyc files, have to
             # use importlib for scripts with other names.
             try:
-                import importlib.util
-                spec = importlib.util.spec_from_file_location('asciidoc', self.cmd)
-                module = importlib.util.module_from_spec(spec)
+                from importlib.util import spec_from_loader, module_from_spec
+                from importlib.machinery import SourceFileLoader
+                loader = SourceFileLoader('asciidoc', self.cmd)
+                spec = spec_from_loader('asciidoc', loader)
+                module = module_from_spec(spec)
                 spec.loader.exec_module(module)
                 self.asciidoc = module
             except ImportError:


### PR DESCRIPTION
Hi guys!

As describe by Simon in [Debian bug #945391](https://bugs.debian.org/945391), when trying to instantiate the asciidocapi with the version I put in Debian based on commit 51d7c14, the loader fails:
```
$ python3
Python 3.7.5 (default, Oct 27 2019, 15:43:29) 
[GCC 9.2.1 20191022] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import io
>>> import sys
>>> sys.path.append('/usr/share/asciidoc')
>>> import asciidocapi
>>> infile = io.StringIO('Test')
>>> outfile = io.StringIO()
>>> adoc = asciidocapi.AsciiDocAPI()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/share/asciidoc/asciidocapi.py", line 209, in __init__
    self.__import_asciidoc()
  File "/usr/share/asciidoc/asciidocapi.py", line 244, in __import_asciidoc
    module = importlib.util.module_from_spec(spec)
  File "<frozen importlib._bootstrap>", line 580, in module_from_spec
AttributeError: 'NoneType' object has no attribute 'loader'
>>> 
```

This patch was proposed by Simon Ruderich in his bug report and it works!

```
$ python3
Python 3.7.5 (default, Oct 27 2019, 15:43:29) 
[GCC 9.2.1 20191022] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import io
>>> import sys
>>> sys.path.append('/usr/share/asciidoc')
>>> import asciidocapi
>>> infile = io.StringIO('Test')
>>> outfile = io.StringIO()
>>> adoc = asciidocapi.AsciiDocAPI()
>>> adoc.execute(infile, outfile)
>>> outfile.getvalue()
*** content stripped here because it's a big html code but it works! ***
```

Thanks for considering this.

Joseph