### PR TITLE
remove testasciidoc.py update line from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
   - sudo apt-get update -yq2
   - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base
 script:
-  - time python tests/testasciidoc.py update
   - python asciidoc.py --doctest
   - python asciidocapi.py
   - time python tests/testasciidoc.py run


### PR DESCRIPTION
It's expected that all test files exist within the repo and Travis should not be responsible for creating/updating any. This should make it clearer for when a PR might break the existing test cases or require updating them.