### PR TITLE
Fix make all incorrectly including spell command for couple files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
       - texlive-latex-base
       - xsltproc
 
+install: false
+
 script:
   - python asciidoc.py --doctest
   - python asciidocapi.py
@@ -27,4 +29,5 @@ script:
   - git clean -x -f doc tests/data
   - autoconf
   - ./configure
+  - xmllint --nonet --noout --valid /home/travis/build/asciidoc/asciidoc-py3/doc/asciidoc.1.xml
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - dvipng
       - graphviz
       - imagemagick
-      #- libxml2-utils
+      - libxml2-utils
       - lilypond
       - source-highlight
       - texlive-latex-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ script:
   - python asciidocapi.py
   - time python tests/testasciidoc.py run
   - git clean -x -f doc tests/data
+  - autoconf
+  - ./configure
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: python
+
 python:
   - 3.5
   - 3.6
   - 3.7
   - 3.8
-install:
-  - sudo apt-get update -yq2
-  - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base
+
+addons:
+  apt:
+    packages:
+      - docbook-xml
+      - docbook-xsl
+      - dvipng
+      - graphviz
+      - imagemagick
+      #- libxml2-utils
+      - lilypond
+      - source-highlight
+      - texlive-latex-base
+      - xsltproc
+
 script:
   - python asciidoc.py --doctest
   - python asciidocapi.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - autoconf
   - ./configure
   - make
-  - make install
+  - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ script:
   - autoconf
   - ./configure
   - make
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,4 @@ script:
   - git clean -x -f doc tests/data
   - autoconf
   - ./configure
-  - xmllint --nonet --noout --valid /home/travis/build/asciidoc/asciidoc-py3/doc/asciidoc.1.xml
   - make

--- a/Makefile.in
+++ b/Makefile.in
@@ -164,22 +164,19 @@ DOC_FILES = CHANGELOG.txt README.asciidoc BUGS.txt INSTALL.txt doc/a2x.1.txt \
 
 WEBSITE_FILES = examples/website/index.txt examples/website/README-website.txt examples/website/support.txt
 
-.PHONY: ${DOC_FILES}
-${DOC_FILES}:
-	aspell check -p ./doc/asciidoc.dict $@
+.PHONY: doc_spell
+doc_spell:
+	@for f in $(DOC_FILES); do \
+		echo "aspell check -p ./doc/asciidoc.dict $$f"; \
+		aspell check -p ./doc/asciidoc.dict $$f; \
+	done
 
-.PHONY: ${WEBSITE_FILES}
-${WEBSITE_FILES}:
-	aspell check -p ./examples/website/asciidoc-website.dict $@
-
-.PHONY: spell_doc
-doc_spell: ${DOC_FILES}
-
-.PHONY: spell_website
-website_spell: ${WEBSITE_FILES}
-
-.PHONY: spell
-spell: doc_spell website_spell
+.PHONY: website_spell
+website_spell:
+	@for f in $(WEBSITE_FILES); do \
+		echo "aspell check -p ./examples/website/asciidoc-website.dict $$f"; \
+		aspell check -p ./examples/website/asciidoc-website.dict $$f; \
+	done
 
 build: fixconfpath $(manp)
 


### PR DESCRIPTION
Running `make` or `make all` would run the `aspell` command for a couple files as the file is included in two different make targets. This fixes the spell commands to not utilize the file-based make targets, but just use a for loop instead.

Travis has been updated to include `make` as one of its build commands to ensure that runs as expected going forward.

closes #89