### PR TITLE
vim-asciidoc: speed up the refresh process for big files

### DIFF
--- a/vim/syntax/asciidoc.vim
+++ b/vim/syntax/asciidoc.vim
@@ -6,7 +6,7 @@
 " Licence:      GPL (http://www.gnu.org)
 " Remarks:      Vim 6 or greater
 " Limitations:
-" 
+"
 " - Nested quoted text formatting is highlighted according to the outer
 "   format.
 " - If a closing Example Block delimiter may be mistaken for a title
@@ -23,8 +23,6 @@ if exists("b:current_syntax")
 endif
 
 syn clear
-syn sync fromstart
-syn sync linebreaks=100
 
 " Run :help syn-priority to review syntax matching priority.
 syn keyword asciidocToDo TODO FIXME CHECK TEST XXX ZZZ DEPRECATED


### PR DESCRIPTION
Hi guys,

The removal of those lines were requested in Debian to speed up vim's refresh process on big files: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767179

It has been there for over 2 years now so I thought I might just push it here too (I'll push it in the vim-asciidoc repo too to keep them in sync while the transition is being done) :)

Thanks,
Joseph