### PR TITLE
Use true for skipping install section for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
       - texlive-latex-base
       - xsltproc
 
-install: false
+install: true
 
 script:
   - python asciidoc.py --doctest


### PR DESCRIPTION
Looks like Travis-CI changed something on their backend that is causing `install: false` to now fail builds. `install: true` should work better, even if it's a bit less intuitive looking (as I guess now Travis is truly executing the `false` / `true` shell commands and directly using their exit codes (`1` / `0` respectively).