### PR TITLE
Search for a2x inline options using bytes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Version 9.0.0 (Unreleased)
 - Fix index terms requiring two characters instead of just one (see https://github.com/asciidoc/asciidoc-py3/pull/2#issuecomment-392605876)
 - Properly capture and use colophon, dedication, and preface for docbooks in Japanese (see https://github.com/asciidoc/asciidoc-py3/pull/2#issuecomment-392623181)
 - make install did not include the unwraplatex.py filter
+- Fix getting a2x options from non-ascii source
 
 .Testing
 - Commit generated test files to the repository for continuous integration

--- a/a2x.py
+++ b/a2x.py
@@ -364,11 +364,11 @@ def get_source_options(asciidoc_file):
     result = []
     if os.path.isfile(asciidoc_file):
         options = ''
-        with open(asciidoc_file) as f:
+        with open(asciidoc_file, 'rb') as f:
             for line in f:
-                mo = re.search(r'^//\s*a2x:', line)
+                mo = re.search(rb'^//\s*a2x:', line)
                 if mo:
-                    options += ' ' + line[mo.end():].strip()
+                    options += ' ' + line[mo.end():].decode('utf8').strip()
         parse_options()
     return result
 


### PR DESCRIPTION
Partial fix for #92 

While there's still improvements to be made in the encode/decode story of asciidoc, this fixes the immediate problem of attempting to parse inline a2x options in non-utf8 files. This does make the assumption that all options are utf8, but I'm not sure if that assumption can be broken looking through the manpage of a2x (maybe though with really wacky filepaths?). 