### PR TITLE
add requires directive to testasciidoc

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Version 9.0.0 (Unreleased)
 - Commit generated test files to the repository for continuous integration
 - Test against Python 3.5+ on Travis-CI
 - Remove symlink tests/asciidocapi.py in favor of just appending to sys.path
+- Add requires directive to testasciidoc.conf to indicate necessary external dependencies (e.g. source-highlight)
 
 Version 8.6.10 (2017-09-22)
 ---------------------------

--- a/tests/testasciidoc.conf
+++ b/tests/testasciidoc.conf
@@ -6,17 +6,26 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Test cases
 
+% requires
+['source-highlight']
+
 % source
 data/testcases.txt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Filters
 
+% requires
+['dot', 'lilypond']
+
 % source
 data/filters-test.txt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Tables
+
+% requires
+['source-highlight']
 
 % source
 ../examples/website/newtables.txt
@@ -29,6 +38,9 @@ data/oldtables.txt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Source highlighter
+
+% requires
+['source-highlight']
 
 % source
 ../doc/source-highlight-filter.txt
@@ -116,6 +128,10 @@ Example slideshow
 % backends
 ['slidy']
 
+% requires
+['source-highlight']
+
+
 % source
 ../doc/slidy-example.txt
 
@@ -155,6 +171,9 @@ LaTeX Math
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 LaTeX Filter
 
+% requires
+['latex', 'dvipng']
+
 % source
 ../doc/latex-filter.txt
 
@@ -175,6 +194,9 @@ data/utf8-examples.txt
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Additional Open Block and Paragraph styles
+
+% requires
+['source-highlight', 'dot']
 
 % source
 data/open-block-test.txt


### PR DESCRIPTION
Part of work for #99 

Adds a new `% requires` directive for the testasciidoc.conf file. This directive is a list of command-line utilities that must exist for that particular test to run.

For example:
```
Additional Open Block and Paragraph styles

% requires
['source-highlight', 'dot']

% source
data/open-block-test.txt
```

This will check that `source-highlight` and `dot` exist (using `shutil.which`) and if one of them does not, the test is skipped.

Does this fit your needs @aerostitch for your second point?