### PR TITLE
allow floating dblatex figures, examples, equations and tables with floatstyle attribute

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Version 9.0.0 (Unreleased)
 - Running `make help` will now print out a helpful usage message
 - Add simplified Chinese translation (thanks @muirmok)
 - vim-asciidoc: speed up the refresh process for big files (thanks @aerostitch)
+- Allow specifying floatstyle attribute for figures, tables, equations, examples in docbook (thanks @psaris)
 
 .Bug fixes
 - Fix index terms requiring two characters instead of just one (see https://github.com/asciidoc/asciidoc-py3/pull/2#issuecomment-392605876)

--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -1342,6 +1342,11 @@ generated HTML].
 'reftext' is used to set the DocBook 'xreflabel' attribute.
 The 'reftext' attribute can an also be set by the 'BlockId' element.
 
+|floatstyle |docbook |
+'floatstyle' is used to specify the float
+option for the titled table, example, image and equation
+blocks. A typical example would be to specify the value as 'floatstyle="[htbp]"'.
+
 |====================================================================
 
 

--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -1343,9 +1343,10 @@ generated HTML].
 The 'reftext' attribute can an also be set by the 'BlockId' element.
 
 |floatstyle |docbook |
-'floatstyle' is used to specify the float
-option for the titled table, example, image and equation
-blocks. A typical example would be to specify the value as 'floatstyle="[htbp]"'.
+'floatstyle' is used to specify the floatstyle attribute for the
+titled table, example, image and equation blocks. This is useful when
+used in conjuction with the dblatex toolchain. A typical example
+would be to specify the value as 'floatstyle="[htbp]"'.
 
 |====================================================================
 

--- a/docbook45.conf
+++ b/docbook45.conf
@@ -62,7 +62,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 </informalequation>
 
 [latexmathblock]
-<equation{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}><title>{title}</title>
+<equation{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}><title>{title}</title>
 {title%}<informalequation{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>
 <alt><![CDATA[\[|\]]]></alt>
 <mediaobject><textobject><phrase></phrase></textobject></mediaobject>
@@ -78,7 +78,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 </inlinemediaobject>
 
 [image-blockmacro]
-<figure{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{pgwide-option? pgwide="1"}><title>{title}</title>
+<figure{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}{pgwide-option? pgwide="1"}><title>{title}</title>
 {title%}<informalfigure{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>{pgwide-option?<?dbfo pgwide="1"?>}
 # DocBook XSL Stylesheets custom processing instructions.
 <?dbfo keep-together="{breakable-option#auto}"?>
@@ -382,7 +382,7 @@ template::[quote-open]
 template::[quote-close]
 
 [exampleblock-open]
-<{title?example}{title!informalexample}{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>
+<{title?example}{title!informalexample}{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}>
 # DocBook XSL Stylesheets custom processing instructions.
 <?dbfo keep-together="{breakable-option#auto}"?>
 <?dbfo keep-together="{unbreakable-option#always}"?>
@@ -439,7 +439,7 @@ paragraph=
 paragraph=
 
 [table]
-<{title?table}{title!informaltable}{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{pgwide-option? pgwide="1"}
+<{title?table}{title!informaltable}{id? id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}{floatstyle? floatstyle="{floatstyle}"}"}{pgwide-option? pgwide="1"}
 frame="{frame=all}"
 {grid%rowsep="1" colsep="1"}
 rowsep="{grid@none|cols:0:1}" colsep="{grid@none|rows:0:1}"

--- a/docbook5.conf
+++ b/docbook5.conf
@@ -60,7 +60,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 </informalequation>
 
 [latexmathblock]
-<equation{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}><title>{title}</title>
+<equation{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}><title>{title}</title>
 {title%}<informalequation{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>
 <alt><![CDATA[\[|\]]]></alt>
 <mediaobject><textobject><phrase></phrase></textobject></mediaobject>
@@ -76,7 +76,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 </inlinemediaobject>
 
 [image-blockmacro]
-<figure{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{pgwide-option? pgwide="1"}><title>{title}</title>
+<figure{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}{pgwide-option? pgwide="1"}><title>{title}</title>
 {title%}<informalfigure{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>{pgwide-option?<?dbfo pgwide="1"?>}
 # DocBook XSL Stylesheets custom processing instructions.
 <?dbfo keep-together="{breakable-option#auto}"?>
@@ -380,7 +380,7 @@ template::[quote-open]
 template::[quote-close]
 
 [exampleblock-open]
-<{title?example}{title!informalexample}{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}>
+<{title?example}{title!informalexample}{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}>
 # DocBook XSL Stylesheets custom processing instructions.
 <?dbfo keep-together="{breakable-option#auto}"?>
 <?dbfo keep-together="{unbreakable-option#always}"?>
@@ -437,7 +437,7 @@ paragraph=
 paragraph=
 
 [table]
-<{title?table}{title!informaltable}{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{pgwide-option? pgwide="1"}
+<{title?table}{title!informaltable}{id? xml:id="{id}"}{role? role="{role}"}{reftext? xreflabel="{reftext}"}{floatstyle? floatstyle="{floatstyle}"}{pgwide-option? pgwide="1"}
 frame="{frame=all}"
 {grid%rowsep="1" colsep="1"}
 rowsep="{grid@none|cols:0:1}" colsep="{grid@none|rows:0:1}"

--- a/tests/data/testcases-docbook.xml
+++ b/tests/data/testcases-docbook.xml
@@ -897,7 +897,7 @@ rowsep="1" colsep="1"
 </tbody>
 </tgroup>
 </table>
-<figure><title>Tiger</title>
+<figure floatstyle="[htbp]"><title>Tiger</title>
 <mediaobject>
   <imageobject>
   <imagedata fileref="../../images/images/tiger.png"/>
@@ -1012,5 +1012,16 @@ Template line 2.</simpara>
 <title>Inline macros</title>
 <simpara><ulink url="http://groups.google.com/group/asciidoc/">A URL with [square
 brackets]</ulink>.</simpara>
+</section>
+<section id="_equation">
+<title>Equation</title>
+<equation floatstyle="[htbp]"><title>Equation</title>
+<alt><![CDATA[\[C = \alpha + \beta Y^{\gamma} + \epsilon\]]]></alt>
+<mediaobject><textobject><phrase></phrase></textobject></mediaobject>
+</equation>
+</section>
+<section id="_example">
+<title>Example</title>
+Formal figures, tables, equations and examples can float in docbook backend
 </section>
 </article>

--- a/tests/data/testcases-docbook5.xml
+++ b/tests/data/testcases-docbook5.xml
@@ -867,7 +867,7 @@ rowsep="1" colsep="1"
 </section>
 <section xml:id="_floating_tables_and_images">
 <title>Floating tables and images</title>
-<table
+<table floatstyle="[htbp]"
 frame="all"
 rowsep="1" colsep="1"
 >
@@ -898,7 +898,7 @@ rowsep="1" colsep="1"
 </tbody>
 </tgroup>
 </table>
-<figure><title>Tiger</title>
+<figure floatstyle="[htbp]"><title>Tiger</title>
 <mediaobject>
   <imageobject>
   <imagedata fileref="../../images/images/tiger.png"/>
@@ -1013,5 +1013,16 @@ Template line 2.</simpara>
 <title>Inline macros</title>
 <simpara><link xlink:href="http://groups.google.com/group/asciidoc/">A URL with [square
 brackets]</link>.</simpara>
+</section>
+<section xml:id="_equation">
+<title>Equation</title>
+<equation floatstyle="[htbp]"><title>Equation</title>
+<alt><![CDATA[\[C = \alpha + \beta Y^{\gamma} + \epsilon\]]]></alt>
+<mediaobject><textobject><phrase></phrase></textobject></mediaobject>
+</equation>
+</section>
+<section xml:id="_example">
+<title>Example</title>
+Formal figures, tables, equations and examples can float in docbook backend
 </section>
 </article>

--- a/tests/data/testcases-html4.html
+++ b/tests/data/testcases-html4.html
@@ -880,6 +880,12 @@ Template line 2.</p>
 <h2><a name="_inline_macros"></a>Inline macros</h2>
 <p><a href="http://groups.google.com/group/asciidoc/">A URL with [square
 brackets]</a>.</p>
+<hr>
+<h2><a name="_equation"></a>Equation</h2>
+\[C = \alpha + \beta Y^{gamma} + \epsilon\]
+<hr>
+<h2><a name="_example"></a>Example</h2>
+Formal figures, tables, equations and examples can float in docbook backend
 <p></p>
 <p></p>
 <hr><p><small>

--- a/tests/data/testcases-html5.html
+++ b/tests/data/testcases-html5.html
@@ -1832,6 +1832,22 @@ Template line 2.</p></div>
 brackets]</a>.</p></div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_equation">Equation</h2>
+<div class="sectionbody">
+<div class="mathblock">
+<div class="content">
+<div class="title">Equation</div>
+\[C = \alpha + \beta Y^{\gamma} + \epsilon\]
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_example">Example</h2>
+<div class="sectionbody">
+Formal figures, tables, equations and examples can float in docbook backend
+</div>
+</div>
 </div>
 <div id="footnotes"><hr></div>
 <div id="footer">

--- a/tests/data/testcases-xhtml11.html
+++ b/tests/data/testcases-xhtml11.html
@@ -1795,6 +1795,22 @@ Template line 2.</p></div>
 brackets]</a>.</p></div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_equation">Equation</h2>
+<div class="sectionbody">
+<div class="mathblock">
+<div class="content">
+<div class="title">Equation</div>
+\[C = \alpha + \beta Y^{\gamma} + \epsilon\]
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_example">Example</h2>
+<div class="sectionbody">
+Formal figures, tables, equations and examples can float in docbook backend
+</div>
+</div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer">

--- a/tests/data/testcases.txt
+++ b/tests/data/testcases.txt
@@ -627,7 +627,7 @@ http://groups.google.com/group/asciidoc/browse_thread/thread/c9238380a1f2507a
 Floating tables and images
 --------------------------
 .Simple table
-[float="left",width="15%"]
+[float="left",width="15%",floatstyle="[htbp]"]
 |=======
 |1 |2 |A
 |3 |4 |B
@@ -635,7 +635,7 @@ Floating tables and images
 |=======
 
 .Tiger
-[float="right"]
+[float="right",floatstyle="[htbp]"]
 image::images/tiger.png["Tiger image"]
 
 unfloat::[]
@@ -800,3 +800,18 @@ Lorum ipsum...
 == Inline macros
 http://groups.google.com/group/asciidoc/[A URL with [square
 brackets\]].
+
+== Equation
+.Equation
+[latexmath]
+[floatstyle="[htbp]"]
+++++++++++++++++++++++++++++++++++++++++++++
+\[C = \alpha + \beta Y^{\gamma} + \epsilon\]
+++++++++++++++++++++++++++++++++++++++++++++
+
+== Example
+.Example
+[floatstyle="[htbp]"]
+++++++++++++++++++++++++++++++++++++++++++++
+Formal figures, tables, equations and examples can float in docbook backend
+++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
dblatex permits setting the floating attribute for figures, examples, equations and tables by specifying the floatstyle attribute.  example xsl shown below:

```xml
<xsl:template match="figure">
  <xsl:text>\begin{figure}</xsl:text>
  <!-- figure placement preference -->
  <xsl:choose>
    <xsl:when test="@floatstyle != ''">
      <xsl:value-of select="@floatstyle"/>
    </xsl:when>
    <xsl:when test="not(@float) or (@float and @float='0')">
      <xsl:text>[H]</xsl:text>
    </xsl:when>
    <xsl:otherwise>
      <xsl:value-of select="$figure.default.position"/>
    </xsl:otherwise>
  </xsl:choose>
  <xsl:text>&#10;</xsl:text>
```

```xml
  <xsl:value-of select="concat('\begin{', $table.env, '}')"/>
  <!-- table placement preference -->
  <xsl:choose>
    <xsl:when test="@floatstyle != ''">
      <xsl:value-of select="@floatstyle"/>
    </xsl:when>
    <xsl:otherwise>
      <xsl:value-of select="$table.default.position"/>
    </xsl:otherwise>
  </xsl:choose>
```

```xml
    <xsl:text>&#10;\begin{dbequation}</xsl:text>
    <!-- float placement preference -->
    <xsl:choose>
      <xsl:when test="@floatstyle != ''">
        <xsl:value-of select="@floatstyle"/>
      </xsl:when>
      <xsl:otherwise>
        <xsl:value-of select="$equation.default.position"/>
      </xsl:otherwise>
    </xsl:choose>
```

```xml
<xsl:template match="example" mode="float">
  <xsl:text>&#10;\begin{example}</xsl:text>
  <!-- float placement preference -->
  <xsl:choose>
    <xsl:when test="@floatstyle != ''">
      <xsl:value-of select="@floatstyle"/>
    </xsl:when>
    <xsl:otherwise>
      <xsl:value-of select="$example.default.position"/>
    </xsl:otherwise>
  </xsl:choose>
```