### PR TITLE
Fix generated links for docbook5 backend

### DIFF
--- a/docbook5.conf
+++ b/docbook5.conf
@@ -569,7 +569,7 @@ ifdef::doctype-article[]
 [header]
 template::[header-declarations]
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="{lang=en}">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="{lang=en}">
 <info>
 template::[docinfo]
 </info>
@@ -687,7 +687,7 @@ ifdef::doctype-book[]
 [header]
 template::[header-declarations]
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="{lang=en}">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="{lang=en}">
 <info>
 template::[docinfo]
 </info>

--- a/tests/data/article-docbook5.xml
+++ b/tests/data/article-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>The Article Title</title>
     <date>2003-12</date>

--- a/tests/data/article-docinfo-docbook5.xml
+++ b/tests/data/article-docinfo-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>The Article Title</title>
     <date>2003-12</date>

--- a/tests/data/book-docbook5.xml
+++ b/tests/data/book-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Book Title Goes Here</title>
     <date>2003-12</date>

--- a/tests/data/book-multi-docbook5.xml
+++ b/tests/data/book-multi-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Multi-Part Book Title Goes Here</title>
     <date>2003-12</date>

--- a/tests/data/deprecated-quotes-docbook5.xml
+++ b/tests/data/deprecated-quotes-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <date>2002-11-25</date>
 </info>

--- a/tests/data/filters-test-docbook5.xml
+++ b/tests/data/filters-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Filter Tests</title>
 </info>

--- a/tests/data/lang-cs-article-test-docbook5.xml
+++ b/tests/data/lang-cs-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="cs">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="cs">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-cs-book-test-docbook5.xml
+++ b/tests/data/lang-cs-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="cs">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="cs">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-de-article-test-docbook5.xml
+++ b/tests/data/lang-de-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="de">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="de">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-de-book-test-docbook5.xml
+++ b/tests/data/lang-de-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="de">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="de">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-en-article-test-docbook5.xml
+++ b/tests/data/lang-en-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-en-book-test-docbook5.xml
+++ b/tests/data/lang-en-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-es-article-test-docbook5.xml
+++ b/tests/data/lang-es-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="es">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="es">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-es-book-test-docbook5.xml
+++ b/tests/data/lang-es-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="es">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="es">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-fr-article-test-docbook5.xml
+++ b/tests/data/lang-fr-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="fr">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="fr">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-fr-book-test-docbook5.xml
+++ b/tests/data/lang-fr-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="fr">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="fr">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-hu-article-test-docbook5.xml
+++ b/tests/data/lang-hu-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="hu">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="hu">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-hu-book-test-docbook5.xml
+++ b/tests/data/lang-hu-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="hu">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="hu">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-it-article-test-docbook5.xml
+++ b/tests/data/lang-it-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-it-book-test-docbook5.xml
+++ b/tests/data/lang-it-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ja-article-test-docbook5.xml
+++ b/tests/data/lang-ja-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ja">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ja">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ja-book-test-docbook5.xml
+++ b/tests/data/lang-ja-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ja">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ja">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-nl-article-test-docbook5.xml
+++ b/tests/data/lang-nl-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="nl">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="nl">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-nl-book-test-docbook5.xml
+++ b/tests/data/lang-nl-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="nl">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="nl">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-pt-BR-article-test-docbook5.xml
+++ b/tests/data/lang-pt-BR-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="pt-BR">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="pt-BR">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-pt-BR-book-test-docbook5.xml
+++ b/tests/data/lang-pt-BR-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="pt-BR">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="pt-BR">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ro-article-test-docbook5.xml
+++ b/tests/data/lang-ro-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ro-book-test-docbook5.xml
+++ b/tests/data/lang-ro-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="it">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ru-article-test-docbook5.xml
+++ b/tests/data/lang-ru-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ru">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ru">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-ru-book-test-docbook5.xml
+++ b/tests/data/lang-ru-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ru">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="ru">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-sv-article-test-docbook5.xml
+++ b/tests/data/lang-sv-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="sv">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="sv">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-sv-book-test-docbook5.xml
+++ b/tests/data/lang-sv-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="sv">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="sv">
 <info>
     <title>Languages Test</title>
     <date>2003-12-21</date>

--- a/tests/data/lang-uk-article-test-docbook5.xml
+++ b/tests/data/lang-uk-article-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="uk">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="uk">
 <info>
     <title>Languages Test</title>
     <date>2011-01-30</date>

--- a/tests/data/lang-uk-book-test-docbook5.xml
+++ b/tests/data/lang-uk-book-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="uk">
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="uk">
 <info>
     <title>Languages Test</title>
     <date>2011-01-30</date>

--- a/tests/data/latex-filter-docbook5.xml
+++ b/tests/data/latex-filter-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>LaTeX Filter</title>
 </info>

--- a/tests/data/latexmath-docbook5.xml
+++ b/tests/data/latexmath-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Embedding LaTeX Math in AsciiDoc dblatex documents</title>
 </info>

--- a/tests/data/newtables-docbook5.xml
+++ b/tests/data/newtables-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>AsciiDoc New tables</title>
 </info>

--- a/tests/data/oldtables-docbook5.xml
+++ b/tests/data/oldtables-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>AsciiDoc Old Tables</title>
 </info>

--- a/tests/data/open-block-test-docbook5.xml
+++ b/tests/data/open-block-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Additional Open Block and Paragraph styles</title>
 </info>

--- a/tests/data/rcs-id-marker-test-docbook5.xml
+++ b/tests/data/rcs-id-marker-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>RCS $Id$ Marker Test</title>
     <date>2009/05/17</date>

--- a/tests/data/source-highlight-filter-docbook5.xml
+++ b/tests/data/source-highlight-filter-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Source Code Highlight Filter</title>
 </info>

--- a/tests/data/testcases-docbook5.xml
+++ b/tests/data/testcases-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>Test <emphasis>Cases</emphasis></title>
     <author>

--- a/tests/data/utf8-bom-test-docbook5.xml
+++ b/tests/data/utf8-bom-test-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>UTF-8 BOM Test</title>
 </info>

--- a/tests/data/utf8-examples-docbook5.xml
+++ b/tests/data/utf8-examples-docbook5.xml
@@ -2,7 +2,7 @@
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
 
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
     <title>UTF-8 encoded sample plain-text file</title>
 </info>


### PR DESCRIPTION
I have located an issue in docbook5 configuration as this is the one that I am using.
Basically the namespace for xlink is defined as xl in the header, but then xlink is used.

Fixed in this PR.