### PR TITLE
update copyright notice to include generic asciidoc contributors

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,6 +1,5 @@
-Copyright (C) 2000-2007 Stuart Rackham
-
-Email: srackham@gmail.com
+Copyright (C) 2000-2013 Stuart Rackham
+Copyright (C) 2013-2020 AsciiDoc Contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -43,6 +43,8 @@ Current AsciiDoc version tested on Ubuntu 18.04 with:
 
 Copying
 -------
-Copyright (C) 2002-2013 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License version 2
-(GPLv2).
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).

--- a/a2x.py
+++ b/a2x.py
@@ -4,11 +4,28 @@
 a2x - A toolchain manager for AsciiDoc (converts Asciidoc text files to other
       file formats)
 
+Free use of this software is granted under the terms of the MIT license.
+
 Copyright (C) 2002-2013 Stuart Rackham.
 Copyright (C) 2013-2020 AsciiDoc Contributors.
 
-Free use of this software is granted under the terms of the GNU General
-Public License version 2 (GPLv2).
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 
 import os

--- a/a2x.py
+++ b/a2x.py
@@ -4,9 +4,11 @@
 a2x - A toolchain manager for AsciiDoc (converts Asciidoc text files to other
       file formats)
 
-Copyright: Stuart Rackham (c) 2009
-License:   MIT
-Email:     srackham@gmail.com
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).
 """
 
 import os

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -3,8 +3,11 @@
 """
 asciidoc - converts an AsciiDoc text file to HTML or DocBook
 
-Copyright (C) 2002-2010 Stuart Rackham. Free use of this software is granted
-under the terms of the GNU General Public License (GPL).
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).
 """
 
 import ast

--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -47,8 +47,11 @@ Doctests:
    AsciiDocError: ERROR: <stdin>: line 1: [blockdef-listing] missing closing delimiter
 
 
-Copyright (C) 2009 Stuart Rackham. Free use of this software is granted
-under the terms of the GNU General Public License (GPL).
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).
 
 """
 

--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -376,6 +376,5 @@ COPYING
 Copyright \(C) 2002-2013 Stuart Rackham.
 Copyright \(C) 2013-2020 AsciiDoc Contributors.
 
-Free use of this software is granted under the terms of the GNU General
-Public License version 2 (GPLv2).
+Free use of this software is granted under the terms of the MIT license.
 

--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -373,6 +373,9 @@ asciidoc(1)
 
 COPYING
 -------
-Copyright \(C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the MIT license.
+Copyright \(C) 2002-2013 Stuart Rackham.
+Copyright \(C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).
 

--- a/doc/asciidoc.1.txt
+++ b/doc/asciidoc.1.txt
@@ -228,6 +228,9 @@ a2x(1)
 
 COPYING
 -------
-Copyright \(C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).
 

--- a/doc/asciidoc.1.txt
+++ b/doc/asciidoc.1.txt
@@ -228,8 +228,8 @@ a2x(1)
 
 COPYING
 -------
-Copyright (C) 2002-2013 Stuart Rackham.
-Copyright (C) 2013-2020 AsciiDoc Contributors.
+Copyright \(C) 2002-2013 Stuart Rackham.
+Copyright \(C) 2013-2020 AsciiDoc Contributors.
 
 Free use of this software is granted under the terms of the GNU General
 Public License version 2 (GPLv2).

--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -2171,7 +2171,7 @@ generating DocBook bibliography entries. Example:
 - [[[taoup]]] Eric Steven Raymond. 'The Art of UNIX
   Programming'. Addison-Wesley. ISBN 0-13-142901-9.
 - [[[walsh-muellner]]] Norman Walsh & Leonard Muellner.
-  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999. 
+  'DocBook - The Definitive Guide'. O'Reilly & Associates. 1999.
   ISBN 1-56592-580-7.
 ---------------------------------------------------------------------
 
@@ -6069,4 +6069,5 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License version 2 for more details.
 
-Copyright (C) 2002-2011 Stuart Rackham.
+Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.

--- a/filters/code/code-filter.py
+++ b/filters/code/code-filter.py
@@ -46,8 +46,11 @@ URLS
     http://asciidoc.org/
 
 COPYING
-    Copyright (C) 2002-2006 Stuart Rackham. Free use of this software is
-    granted under the terms of the GNU General Public License (GPL).
+    Copyright (C) 2002-2013 Stuart Rackham.
+    Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+    Free use of this software is granted under the terms of the GNU General
+    Public License version 2 (GPLv2).
 '''
 
 import os, sys, re

--- a/filters/latex/latex2img.py
+++ b/filters/latex/latex2img.py
@@ -54,8 +54,11 @@ AUTHOR
     http://code.google.com/p/latexmath2png/
 
 COPYING
-    Copyright (C) 2010 Stuart Rackham. Free use of this software is
-    granted under the terms of the MIT License.
+    Copyright (C) 2002-2013 Stuart Rackham.
+    Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+    Free use of this software is granted under the terms of the GNU General
+    Public License version 2 (GPLv2).
 '''
 
 import os, sys, tempfile

--- a/filters/music/music2png.py
+++ b/filters/music/music2png.py
@@ -46,8 +46,11 @@ AUTHOR
     Written by Stuart Rackham, <srackham@gmail.com>
 
 COPYING
-    Copyright (C) 2006 Stuart Rackham. Free use of this software is
-    granted under the terms of the GNU General Public License (GPL).
+    Copyright (C) 2002-2013 Stuart Rackham.
+    Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+    Free use of this software is granted under the terms of the GNU General
+    Public License version 2 (GPLv2).
 '''
 
 import os, sys, tempfile

--- a/help.conf
+++ b/help.conf
@@ -193,8 +193,11 @@ RESOURCES
 
 COPYING
 
-   Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-   granted under the terms of the GNU General Public License (GPL).
+   Copyright (C) 2002-2013 Stuart Rackham.
+   Copyright (C) 2013-2020 AsciiDoc Contributors.
+
+   Free use of this software is granted under the terms of the GNU General
+   Public License version 2 (GPLv2).
 
 
 [syntax]
@@ -258,7 +261,7 @@ Section title underlines
 
   Single line:
 
-  = Level 0 =                 (document title) 
+  = Level 0 =                 (document title)
   == Level 1 ==
   === Level 2 ===
   ==== Level 3 ====

--- a/tests/data/asciidoc.1-docbook.xml
+++ b/tests/data/asciidoc.1-docbook.xml
@@ -458,7 +458,9 @@ contributed to it.</simpara>
 </refsect1>
 <refsect1 id="_copying">
 <title>COPYING</title>
-<simpara>Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).</simpara>
+<simpara>Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.</simpara>
+<simpara>Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).</simpara>
 </refsect1>
 </refentry>

--- a/tests/data/asciidoc.1-docbook5.xml
+++ b/tests/data/asciidoc.1-docbook5.xml
@@ -457,7 +457,9 @@ contributed to it.</simpara>
 </refsect1>
 <refsect1 xml:id="_copying">
 <title>COPYING</title>
-<simpara>Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).</simpara>
+<simpara>Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.</simpara>
+<simpara>Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).</simpara>
 </refsect1>
 </refentry>

--- a/tests/data/asciidoc.1-html4.html
+++ b/tests/data/asciidoc.1-html4.html
@@ -371,8 +371,10 @@ contributed to it.</p>
 <h2><a name="_see_also"></a>SEE ALSO</h2>
 <p>a2x(1)</p>
 <h2><a name="_copying"></a>COPYING</h2>
-<p>Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).</p>
+<p>Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.</p>
+<p>Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).</p>
 <p></p>
 <p></p>
 <hr><p><small>

--- a/tests/data/asciidoc.1-html5.html
+++ b/tests/data/asciidoc.1-html5.html
@@ -1148,8 +1148,10 @@ contributed to it.</p></div>
 <div class="sect1">
 <h2 id="_copying">COPYING</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).</p></div>
+<div class="paragraph"><p>Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.</p></div>
+<div class="paragraph"><p>Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).</p></div>
 </div>
 </div>
 </div>

--- a/tests/data/asciidoc.1-xhtml11.html
+++ b/tests/data/asciidoc.1-xhtml11.html
@@ -1150,8 +1150,10 @@ contributed to it.</p></div>
 <div class="sect1">
 <h2 id="_copying">COPYING</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (C) 2002-2011 Stuart Rackham. Free use of this software is
-granted under the terms of the GNU General Public License (GPL).</p></div>
+<div class="paragraph"><p>Copyright (C) 2002-2013 Stuart Rackham.
+Copyright (C) 2013-2020 AsciiDoc Contributors.</p></div>
+<div class="paragraph"><p>Free use of this software is granted under the terms of the GNU General
+Public License version 2 (GPLv2).</p></div>
 </div>
 </div>
 </div>

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-__version__ = '0.2.0'
-__copyright__ = 'Copyright (C) 2009 Stuart Rackham'
+__version__ = '0.3.0'
 
 
 import difflib

--- a/website/index.txt
+++ b/website/index.txt
@@ -16,8 +16,6 @@ full list of all additions, changes and bug fixes. Changes are
 documented in the updated link:userguide.html[User Guide]. See the
 link:INSTALL.html[Installation page] for downloads and and
 installation instructions.
-
-'Matthew Peveler'
 ************************************************************************
 
 Introduction


### PR DESCRIPTION
This unifies and updates the copyright notice across the codebase such that the time Stuart worked on it (till about Nov 2013) and then after that it was handled by just the generic "AsciiDoc Contributors" byline. Can update this to put a specific person's name if requested.

I've also made it clear that the codebase is licensed under GPLv2 throughout where GPL was used, and added the full MIT license text to a2x as that's under the MIT for some reason.