### PR TITLE
use lru_cache for macros.match

### DIFF
--- a/asciidoc.py
+++ b/asciidoc.py
@@ -10,6 +10,7 @@ under the terms of the GNU General Public License (GPL).
 import ast
 import copy
 import csv
+from functools import lru_cache
 import getopt
 import io
 import locale
@@ -3937,6 +3938,7 @@ class Macros:
                         return m
         return False
 
+    @lru_cache(maxsize=2048)
     def match(self, prefix, name, text):
         """Return re match object matching 'text' with macro type 'prefix',
         macro name 'name'."""


### PR DESCRIPTION
The [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) is used to create a cache of function calls to results. As the `macros.match` function is called a lot, usually with the same arguments, we can utilize this function to store the results between calls. While I could set the max_items parameter to be higher here, increasing it by 100x only really amounts to a ~0.02s speed-up or so, at the cost of more memory being consumed during parsing. Better speed-ups would be to rewrite the macro system such that missed calls then fall-back to utilize something like out of #49.