### PR TITLE
add AsciiDoc trademark notice to README and website footer

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -49,3 +49,5 @@ Copyright (C) 2013-2020 AsciiDoc Contributors.
 
 Free use of this software is granted under the terms of the GNU General
 Public License version 2 (GPLv2).
+
+AsciiDoc is a trademark of the Eclipse Foundation, Inc.

--- a/website/layout2.conf
+++ b/website/layout2.conf
@@ -124,7 +124,8 @@ endif::doctype-manpage[]
 <div id="footer">
 <div id="footer-text">
 Version {revnumber}<br />
-Last updated {localdate} {localtime}
+Last updated {localdate} {localtime}<br />
+AsciiDoc is a trademark of the Eclipse Foundation, Inc.
 </div>
 ifdef::badges[]
 <div id="footer-badges">


### PR DESCRIPTION
As part of the formation of the AsciiDoc Working Group at the Eclipse Foundation, the AsciiDoc trademark was transferred to the Eclipse Foundation in order to protect it. Since the AsciiDoc Python project predated the creation of the Working Group, and in fact originated the language, it is permitted to continue using "AsciiDoc" in the project name, even without demonstrating compliance (though my hope is that it eventually will, in some form). However, what is required is to add a notice to the README and website footer that AsciiDoc is a trademark of the Eclipse Foundation, Inc. That's the change proposed by this PR.

If you have any questions are concerns, please feel free to raise them.