### PR TITLE
Add testasciidoc.1 to MANIFEST.in for release assets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,9 @@
 dblatex/*
-doc/a2x.1
-doc/asciidoc.1
 doc/asciidoc.conf
 doc/article-docinfo.xml
 doc/customers.csv
 doc/*.txt
+doc/*.1
 doc/asciidoc.dict
 docbook-xsl/*
 filters/**/*


### PR DESCRIPTION
Closes #136 

The generated `./doc/testasciidoc.1` will now be included within the release assets.