### PR TITLE
Avoid Extra Empty Lines In Preformatted Blocks

### DIFF
--- a/asciidoc.py
+++ b/asciidoc.py
@@ -4594,7 +4594,7 @@ class Writer:
         if fname == '<stdout>':
             self.f = sys.stdout
         else:
-            self.f = open(fname, 'w+', encoding='utf-8')
+            self.f = open(fname, 'w+', encoding='utf-8', newline="")
         message.verbose('writing: ' + writer.fname, False)
         if bom:
             self.f.write(bom)


### PR DESCRIPTION
Problems noticed on Windows where preformatted blocks (e.g. source & literal blocks) have an extra space between each line.  In fact, *all* lines have this extra space, but it is only noticeable on preformatted blocks where the extra line spacing is visible.

By default, Python 3 has universal newlines mode enabled, which makes outputting files with various line endings simpler.  However, AsciiDoc is already handling this internally, so we ended up with extra lines being inserted.  In the actual output file, every line on Windows ended with "/r/r/n".  This was not a problem on systems that used UNIX line endings.

Solve this by disabling universal newlines when outputting the file.

This is for #139