### PR TITLE
add simple CI test for running asciidoc on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,21 @@ jobs:
           sudo make install
 
       - run: asciidoc --version
+
+  test-windows:
+    needs: lint
+    runs-on: windows-latest
+    env:
+      python-version: 3.6
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ env.python-version }}
+
+      - run: python asciidoc.py --doctest
+      - run: python asciidocapi.py
+      - run: python tests/testasciidoc.py run --number 6


### PR DESCRIPTION
This puts into place a CI run for testing asciidoc on windows, though only on a minimal example, due to it lacking much of the dependencies that are easy to install on Linux. This will help validate behavior to ensure things work same on both platforms, sans filters. Related to #139 