### PR TITLE
use DEFAULT_NEWLINE constant for line ending for generated test sources

### DIFF
--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -13,6 +13,7 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 import asciidocapi  # noqa: E402
+from asciidoc import DEFAULT_NEWLINE  # noqa: E402
 
 # Default backends.
 BACKENDS = ('html4', 'xhtml11', 'docbook', 'docbook5', 'html5')
@@ -196,7 +197,7 @@ class AsciiDocTest(object):
             os.mkdir(self.datadir)
         with open(self.backend_filename(backend), 'w+', encoding='utf-8') as open_file:
             print('WRITING: %s' % open_file.name)
-            open_file.writelines([s + os.linesep for s in lines])
+            open_file.writelines([s + DEFAULT_NEWLINE for s in lines])
 
     def update(self, backend=None, force=False):
         """


### PR DESCRIPTION
Currently, the testasciidoc.py when generating the test results will use the OS' line separator, which means that all of the generated files, which were created on Linux, use `\n` as the line ending. This makes it so that we use the default line ending for generating the files, which will then be used in a future PR to ensure that asciidoc is writing out the files as expected with the right line endings.

After merging this, the next PRs are:

* Update all of the generated test data to use the new line endings
* Update the tests to actually consider line endings as part of the diff check