### PR TITLE
print source file when updating test data

### DIFF
--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -93,7 +93,8 @@ class AsciiDocTest(object):
         return '%s-%s%s' % (
                 os.path.normpath(os.path.join(self.datadir, self.name)),
                 backend,
-                BACKEND_EXT[backend])
+                BACKEND_EXT[backend]
+        )
 
     def parse(self, lines, confdir, datadir):
         """
@@ -207,9 +208,13 @@ class AsciiDocTest(object):
             backends = self.backends
         else:
             backends = [backend]
+
+        print('SOURCE: asciidoc: %s' % self.source)
         for backend in backends:
             if force or self.is_missing_or_outdated(backend):
                 self.update_expected(backend)
+        print()
+
         self.clean_artifacts()
 
     def run(self, backend=None):


### PR DESCRIPTION
This changes the output when doing `python3 tests/testasciidoc.py update` to better match the output when doing `run` by printing out the source per file, and then also inserting a newline between blocks of files. Makes things to parse in my opinion:

Old output:
```
WRITING: tests/data/testcases-html4.html
WRITING: tests/data/testcases-xhtml11.html
WRITING: tests/data/testcases-docbook.xml
WRITING: tests/data/testcases-docbook5.xml
WRITING: tests/data/testcases-html5.html
WRITING: tests/data/newtables-html4.html
WRITING: tests/data/newtables-xhtml11.html
WRITING: tests/data/newtables-docbook.xml
WRITING: tests/data/newtables-docbook5.xml
WRITING: tests/data/newtables-html5.html
```

new output:
```text
SOURCE: asciidoc: tests/data/testcases.txt
WRITING: tests/data/testcases-html4.html
WRITING: tests/data/testcases-xhtml11.html
WRITING: tests/data/testcases-docbook.xml
WRITING: tests/data/testcases-docbook5.xml
WRITING: tests/data/testcases-html5.html

SOURCE: asciidoc: website/newtables.txt
WRITING: tests/data/newtables-html4.html
WRITING: tests/data/newtables-xhtml11.html
WRITING: tests/data/newtables-docbook.xml
WRITING: tests/data/newtables-docbook5.xml
WRITING: tests/data/newtables-html5.html
```