### PR TITLE
cut v9.0.4 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,15 @@ AsciiDoc ChangeLog
 
 :website: https://asciidoc.org/
 
+Version 9.0.4 (2020-10-20)
+--------------------------
+.Bug fixes
+- Fix listing out installed plugins (e.g. --filter list)
+
+.Testing
+- Update to deadsnakes/python@v2.0.0 for testing dev python versions
+- Move from testing against 3.9-dev to stable 3.9
+
 Version 9.0.3 (2020-10-05)
 --------------------------
 .Bug fixes

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Version 9.0.4 (2020-10-20)
 --------------------------
 .Bug fixes
 - Fix listing out installed plugins (e.g. --filter list)
+- Fix python version check failing on 3.10 (thanks @hoadlck)
 
 .Testing
 - Update to deadsnakes/python@v2.0.0 for testing dev python versions

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Version 9.0.4 (2020-10-20)
 .Testing
 - Update to deadsnakes/python@v2.0.0 for testing dev python versions
 - Move from testing against 3.9-dev to stable 3.9
+- Add 3.10-dev test target
 
 Version 9.0.3 (2020-10-05)
 --------------------------

--- a/a2x.py
+++ b/a2x.py
@@ -42,7 +42,7 @@ import xml.dom.minidom
 import mimetypes
 
 PROG = os.path.basename(os.path.splitext(__file__)[0])
-VERSION = '9.0.3'
+VERSION = '9.0.4'
 
 # AsciiDoc global configuration file directory.
 # NOTE: CONF_DIR is "fixed up" by Makefile -- don't rename or change syntax.

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -33,7 +33,7 @@ from ast import literal_eval
 from collections import OrderedDict
 
 # Used by asciidocapi.py #
-VERSION = '9.0.3'           # See CHANGELOG file for version history.
+VERSION = '9.0.4'           # See CHANGELOG file for version history.
 
 MIN_PYTHON_VERSION = '3.5'  # Require this version of Python or better.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
-AC_INIT(asciidoc, 9.0.3)
+AC_INIT(asciidoc, 9.0.4)
 
-AC_SUBST([PACKAGE_DATE], ['05 October 2020'])
+AC_SUBST([PACKAGE_DATE], ['20 October 2020'])
 
 AC_CONFIG_FILES(Makefile)
 


### PR DESCRIPTION
```
Version 9.0.4 (2020-10-20)
--------------------------
.Bug fixes
- Fix listing out installed plugins (e.g. --filter list)

.Testing
- Update to deadsnakes/python@v2.0.0 for testing dev python versions
- Move from testing against 3.9-dev to stable 3.9
```