### PR TITLE
cut 9.0.5 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,14 @@ AsciiDoc ChangeLog
 
 :website: https://asciidoc.org/
 
+Version 9.0.5 (2020-12-12)
+--------------------------
+.Bug fixes
+- Use config newline setting in system attribute evaulation (thanks @hoadlck)
+
+.Testing
+- Update to deadsnakes/python@v2.0.2
+
 Version 9.0.4 (2020-10-20)
 --------------------------
 .Bug fixes

--- a/a2x.py
+++ b/a2x.py
@@ -42,7 +42,7 @@ import xml.dom.minidom
 import mimetypes
 
 PROG = os.path.basename(os.path.splitext(__file__)[0])
-VERSION = '9.0.4'
+VERSION = '9.0.5'
 
 # AsciiDoc global configuration file directory.
 # NOTE: CONF_DIR is "fixed up" by Makefile -- don't rename or change syntax.

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -33,7 +33,7 @@ from ast import literal_eval
 from collections import OrderedDict
 
 # Used by asciidocapi.py #
-VERSION = '9.0.4'           # See CHANGELOG file for version history.
+VERSION = '9.0.5'           # See CHANGELOG file for version history.
 
 MIN_PYTHON_VERSION = (3, 5)  # Require this version of Python or better.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
-AC_INIT(asciidoc, 9.0.4)
+AC_INIT(asciidoc, 9.0.5)
 
-AC_SUBST([PACKAGE_DATE], ['20 October 2020'])
+AC_SUBST([PACKAGE_DATE], ['12 December 2020'])
 
 AC_CONFIG_FILES(Makefile)
 


### PR DESCRIPTION
```
Version 9.0.5 (2020-12-12)
--------------------------
.Bug fixes
- Use config newline setting in system attribute evaulation (thanks @hoadlck)

.Testing
- Update to deadsnakes/python@v2.0.2
```