### PR TITLE
Add future-compat attribute parsing

### DIFF
--- a/asciidoc/__init__.py
+++ b/asciidoc/__init__.py
@@ -35,29 +35,6 @@ def get_compat_mode() -> int:
     return COMPAT_MODE
 
 
-COMPAT_MODE = 1
-
-
-def set_legacy_compat() -> None:
-    set_compat_mode(1)
-
-
-def set_future_compat() -> None:
-    set_compat_mode(2)
-
-
-def set_compat_mode(mode: int) -> None:
-    if mode < 1 or mode > 2:
-        raise ValueError('compat mode must be 1 <= mode <= 2')
-
-    global COMPAT_MODE
-    COMPAT_MODE = mode
-
-
-def get_compat_mode() -> int:
-    return COMPAT_MODE
-
-
 # If running as a script, we avoid these imports to avoid a circular
 # RuntimeWarning, which is fine as we don't use them in that case.
 if "-m" not in sys.argv:

--- a/asciidoc/__init__.py
+++ b/asciidoc/__init__.py
@@ -5,6 +5,24 @@ from .__metadata__ import VERSION, __version__
 
 __all__ = ['VERSION', '__version__']
 
+COMPAT_MODE = 1
+
+def set_legacy_compat() -> None:
+    set_compat_mode(1)
+
+def set_future_compat() -> None:
+    set_compat_mode(2)
+
+def set_compat_mode(mode: int) -> None:
+    if mode < 1 or mode > 2:
+        raise ValueError('compat mode must be 1 <= mode <= 2')
+
+    global COMPAT_MODE
+    COMPAT_MODE = mode
+
+def get_compat_mode() -> int:
+    return COMPAT_MODE
+
 # If running as a script, we avoid these imports to avoid a circular
 # RuntimeWarning, which is fine as we don't use them in that case.
 if "-m" not in sys.argv:

--- a/asciidoc/__init__.py
+++ b/asciidoc/__init__.py
@@ -7,11 +7,14 @@ __all__ = ['VERSION', '__version__']
 
 COMPAT_MODE = 1
 
+
 def set_legacy_compat() -> None:
     set_compat_mode(1)
 
+
 def set_future_compat() -> None:
     set_compat_mode(2)
+
 
 def set_compat_mode(mode: int) -> None:
     if mode < 1 or mode > 2:
@@ -20,8 +23,10 @@ def set_compat_mode(mode: int) -> None:
     global COMPAT_MODE
     COMPAT_MODE = mode
 
+
 def get_compat_mode() -> int:
     return COMPAT_MODE
+
 
 # If running as a script, we avoid these imports to avoid a circular
 # RuntimeWarning, which is fine as we don't use them in that case.

--- a/asciidoc/attrs.py
+++ b/asciidoc/attrs.py
@@ -1,6 +1,7 @@
 import re
 import typing
 
+from . import get_compat_mode
 from .utils import get_args, get_kwargs
 
 
@@ -15,16 +16,90 @@ def parse_attributes(attrs: str, output_dict: typing.Dict) -> None:
     output_dict: {}
 
     attrs: 'hello,world'
-    output_dict: {'2': 'world', '0': 'hello,world', '1': 'hello'}
+    output_dict: {'0': 'hello,world', '1': 'hello', '2': 'world',}
 
     attrs: '"hello", planet="earth"'
-    output_dict: {'planet': 'earth', '0': '"hello", planet="earth"', '1': 'hello'}
+    output_dict: {'0': '"hello", planet="earth"', '1': 'hello' 'planet': 'earth', }
     """
     if not attrs:
         return
     output_dict['0'] = attrs
     # Replace line separators with spaces so line spanning works.
     s = re.sub(r'\s', ' ', attrs)
+    d = legacy_parse(s) if get_compat_mode() == 1 else future_parse(s)
+    output_dict.update(d)
+    print(d)
+    assert len(d) > 0
+
+
+def future_parse(s: str) -> dict:
+    d = {}
+    key = ''
+    value = ''
+    count = 1
+    quote = None
+    in_quotes = False
+    had_quotes = False
+    next_value = False
+
+    def add_value():
+        nonlocal count, d, key, value, next_value
+        if had_quotes:
+            value = value[1:-1]
+        value = value.rstrip()
+        try:
+            value = int(value)
+        except ValueError:
+            pass
+
+        if next_value and not value and not had_quotes:
+            value = None
+
+        if key:
+            d[key] = value
+            key = ''
+        else:
+            d[f'{count}'] = value
+            count += 1
+        value = ''
+        next_value = False
+
+    for i in range(len(s)):
+        char = s[i]
+
+        if char == ',' and not in_quotes:
+            add_value()
+            next_value = True
+            had_quotes = False
+        elif value and char == '=' and not in_quotes:
+            key = value
+            value = ''
+        elif not in_quotes and (char == '"' or char == "'") and (i == 0 or s[i - 1] != '\\'):
+            in_quotes = True
+            quote = char
+            value += char
+        elif in_quotes and char == quote and (i == 0 or s[i - 1] != '\\'):
+            in_quotes = False
+            had_quotes = True
+            quote = None
+            value += char
+        elif char == ' ' and not in_quotes and not value:
+            pass
+        elif char == '\\' and i < len(s) - 1 and (s[i + 1] == '"' or s[i + 1] == "'"):
+            pass
+        else:
+            value += char
+
+    if key and not value:
+        value = key + "="
+        key = ""
+
+    if had_quotes or value or key or next_value:
+        add_value()
+    return d
+
+
+def legacy_parse(s: str) -> dict:
     d = {}
     try:
         d.update(get_args(s))
@@ -47,5 +122,4 @@ def parse_attributes(attrs: str, output_dict: typing.Dict) -> None:
         for k in list(d.keys()):  # Drop any empty positional arguments.
             if d[k] == '':
                 del d[k]
-    output_dict.update(d)
-    assert len(d) > 0
+    return d

--- a/asciidoc/attrs.py
+++ b/asciidoc/attrs.py
@@ -54,7 +54,7 @@ def future_parse(s: str) -> dict:
             d[key] = value if value else ''
             key = ''
         else:
-            d[f'{count}'] = value
+            d["{}".format(count)] = value
         count += 1
         value = ''
 

--- a/asciidoc/attrs.py
+++ b/asciidoc/attrs.py
@@ -28,7 +28,6 @@ def parse_attributes(attrs: str, output_dict: typing.Dict) -> None:
     s = re.sub(r'\s', ' ', attrs)
     d = legacy_parse(s) if get_compat_mode() == 1 else future_parse(s)
     output_dict.update(d)
-    print(d)
     assert len(d) > 0
 
 
@@ -40,41 +39,36 @@ def future_parse(s: str) -> dict:
     quote = None
     in_quotes = False
     had_quotes = False
-    next_value = False
 
     def add_value():
-        nonlocal count, d, key, value, next_value
+        nonlocal count, d, key, value
+        key = key.strip()
+        value = value.strip()
         if had_quotes:
             value = value[1:-1]
-        value = value.rstrip()
-        try:
-            value = int(value)
-        except ValueError:
-            pass
 
-        if next_value and not value and not had_quotes:
+        if not value and not had_quotes:
             value = None
 
         if key:
-            d[key] = value
+            d[key] = value if value else ''
             key = ''
         else:
             d[f'{count}'] = value
-            count += 1
+        count += 1
         value = ''
-        next_value = False
 
     for i in range(len(s)):
         char = s[i]
 
         if char == ',' and not in_quotes:
             add_value()
-            next_value = True
             had_quotes = False
         elif value and char == '=' and not in_quotes:
             key = value
             value = ''
-        elif not in_quotes and (char == '"' or char == "'") and (i == 0 or s[i - 1] != '\\'):
+        elif not in_quotes and (char == '"' or char == "'") \
+                and (i == 0 or s[i - 1] != '\\'):
             in_quotes = True
             quote = char
             value += char
@@ -83,18 +77,19 @@ def future_parse(s: str) -> dict:
             had_quotes = True
             quote = None
             value += char
-        elif char == ' ' and not in_quotes and not value:
-            pass
         elif char == '\\' and i < len(s) - 1 and (s[i + 1] == '"' or s[i + 1] == "'"):
             pass
         else:
             value += char
 
-    if key and not value:
+    if key and key[0] == '=' and not value:
         value = key + "="
         key = ""
 
-    if had_quotes or value or key or next_value:
+    if not value and s.rstrip()[-1] == ',':
+        value = ' '
+
+    if had_quotes or value or key:
         add_value()
     return d
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from asciidoc import set_future_compat, set_legacy_compat
 import pytest
 
+
 @pytest.fixture
 def enable_future_compat() -> None:
     set_future_compat()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from asciidoc import set_future_compat, set_legacy_compat
+import pytest
+
+@pytest.fixture
+def enable_future_compat() -> None:
+    set_future_compat()
+    yield
+    set_legacy_compat()

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -3,6 +3,29 @@ import pytest
 
 
 testcases = {
+    # these test cases fail under future mode
+    "pure_legacy": (
+        # In future mode, all values are always strings
+        (
+            'height=100,caption="",link="images/octocat.png"',
+            {
+                '0': 'height=100,caption="",link="images/octocat.png"',
+                'height': 100,
+                'caption': '',
+                'link': 'images/octocat.png',
+            },
+        ),
+        (
+            "height=100,caption='',link='images/octocat.png'",
+            {
+                '0': "height=100,caption='',link='images/octocat.png'",
+                'height': 100,
+                'caption': '',
+                'link': 'images/octocat.png',
+            },
+        ),
+    ),
+    # these test cases pass under both legacy and future modes
     "legacy": (
         # docstring tests
         ('', {}),
@@ -30,26 +53,11 @@ testcases = {
         ),
         ('=foo=', {'0': '=foo=', '1': '=foo='}),
         ('foo="bar"', {'0': 'foo="bar"', 'foo': 'bar'}),
-        (
-            'height=100,caption="",link="images/octocat.png"',
-            {
-                '0': 'height=100,caption="",link="images/octocat.png"',
-                'height': 100,
-                'caption': '',
-                'link': 'images/octocat.png',
-            },
-        ),
+
         ('foo=\'bar\'', {'0': 'foo=\'bar\'', 'foo': 'bar'}),
-        (
-            "height=100,caption='',link='images/octocat.png'",
-            {
-                '0': "height=100,caption='',link='images/octocat.png'",
-                'height': 100,
-                'caption': '',
-                'link': 'images/octocat.png',
-            },
-        ),
+
     ),
+    # these tests only pass under future mode
     # tests taken from
     # https://github.com/asciidoctor/asciidoctor/blob/main/test/attribute_list_test.rb
     "future": (
@@ -58,72 +66,92 @@ testcases = {
         ('name=\'{val}', {'0': 'name=\'{val}', 'name': '\'{val}'}),
         ('quote , ', {'0': 'quote , ', '1': 'quote', '2': None}),
         (', John Smith', {'0': ', John Smith', '1': None, '2': 'John Smith'}),
-        # (
-        #     'first,,third,',
-        #     {'0': 'first,,third,', '1': 'first', '2': None, '3': 'third', '4': None}
-        # ),
-        # ('foo=bar', {'0': 'foo=bar', 'foo': 'bar'}),
-        # ('foo=', {'0': 'foo=', 'foo': ''}),
-        # ('foo=,bar=baz', {'0': 'foo=,bar=baz', 'foo': '', 'bar': 'baz'}),
-        # (
-        #     'first=value, second=two, third=3',
-        #     {
-        #         '0': 'first=value, second=two, third=3',
-        #         'first': 'value',
-        #         'second': 'two',
-        #         'third': '3',
-        #     },
-        # ),
-        # (
-        #     'first=\'value\', second="value two", third=three',
-        #     {
-        #         '0': 'first=\'value\', second="value two", third=three',
-        #         'first': 'value',
-        #         'second': 'value two',
-        #         'third': 'three',
-        #     },
-        # ),
-        # (
-        #     "     first    =     'value', second     =\"value two\"     , third=       three      ", # noqa: E501
-        #     {
-        #         '0': "     first    =     'value', second     =\"value two\"     , third=       three      ", # noqa: E501
-        #         'first': 'value',
-        #         'second': 'value two',
-        #         'third': 'three',
-        #     },
-        # ),
-        # (
-        #     'first, second="value two", third=three, Sherlock Holmes',
-        #     {
-        #         '0': 'first, second="value two", third=three, Sherlock Holmes',
-        #         '1': 'first',
-        #         'second': 'value two',
-        #         'third': 'three',
-        #         '4': 'Sherlock Holmes',
-        #     },
-        # ),
-        # (
-        #     'first,,third=,,fifth=five',
-        #     {
-        #         '0': 'first,,third=,,fifth=five',
-        #         '1': 'first',
-        #         '2': None,
-        #         'third': '',
-        #         '4': None,
-        #         'fifth': 'five',
-        #     },
-        # ),
+        (
+            'first,,third,',
+            {'0': 'first,,third,', '1': 'first', '2': None, '3': 'third', '4': None}
+        ),
+        ('foo=bar', {'0': 'foo=bar', 'foo': 'bar'}),
+        ('foo=', {'0': 'foo=', 'foo': ''}),
+        ('foo=,bar=baz', {'0': 'foo=,bar=baz', 'foo': '', 'bar': 'baz'}),
+        (
+            'height=100,caption="",link="images/octocat.png"',
+            {
+                '0': 'height=100,caption="",link="images/octocat.png"',
+                'height': '100',
+                'caption': '',
+                'link': 'images/octocat.png',
+            },
+        ),
+        (
+            "height=100,caption='',link='images/octocat.png'",
+            {
+                '0': "height=100,caption='',link='images/octocat.png'",
+                'height': '100',
+                'caption': '',
+                'link': 'images/octocat.png',
+            },
+        ),
+        (
+            'first=value, second=two, third=3',
+            {
+                '0': 'first=value, second=two, third=3',
+                'first': 'value',
+                'second': 'two',
+                'third': '3',
+            },
+        ),
+        (
+            'first=\'value\', second="value two", third=three',
+            {
+                '0': 'first=\'value\', second="value two", third=three',
+                'first': 'value',
+                'second': 'value two',
+                'third': 'three',
+            },
+        ),
+        (
+            "     first    =     'value', second     =\"value two\"     , third=       three      ",  # noqa: E501
+            {
+                '0': "     first    =     'value', second     =\"value two\"     , third=       three      ",  # noqa: E501
+                'first': 'value',
+                'second': 'value two',
+                'third': 'three',
+            },
+        ),
+        (
+            'first, second="value two", third=three, Sherlock Holmes',
+            {
+                '0': 'first, second="value two", third=three, Sherlock Holmes',
+                '1': 'first',
+                'second': 'value two',
+                'third': 'three',
+                '4': 'Sherlock Holmes',
+            },
+        ),
+        (
+            'first,,third=,,fifth=five',
+            {
+                '0': 'first,,third=,,fifth=five',
+                '1': 'first',
+                '2': None,
+                'third': '',
+                '4': None,
+                'fifth': 'five',
+            },
+        ),
     )
 }
 
+
 @pytest.mark.parametrize(
     "input,expected",
-    testcases["legacy"],
+    testcases["legacy"] + testcases["pure_legacy"],
 )
 def test_parse_attributes(input, expected):
     output = dict()
     attrs.parse_attributes(input, output)
     assert output == expected
+
 
 @pytest.mark.parametrize(
     "input,expected",

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -2,9 +2,8 @@ from asciidoc import attrs
 import pytest
 
 
-@pytest.mark.parametrize(
-    "input,expected",
-    (
+testcases = {
+    "legacy": (
         # docstring tests
         ('', {}),
         ('hello,world', {'0': 'hello,world', '1': 'hello', '2': 'world'}),
@@ -14,19 +13,13 @@ import pytest
         ),
         # tests taken from
         # https://github.com/asciidoctor/asciidoctor/blob/main/test/attribute_list_test.rb
-        # commented out tests are currently supported by asciidoc.py
         ('quote', {'0': 'quote', '1': 'quote'}),
         ('"quote"', {'0': '"quote"', '1': 'quote'}),
         ('""', {'0': '""', '1': ''}),
-        # ('"ba\"zaar"', {'0': '"ba\"zaar"', '1': 'ba"zaar'}),
         ("'quote'", {'0': "'quote'", '1': 'quote'}),
         ("''", {'0': "''", '1': ''}),
         ('\'', {'0': '\'', '1': '\''}),
-        # ('name=\'', {'0': 'name=\'', 'name': '\''}),
-        # ('name=\'{val}', {'0': 'name=\'{val}', 'name': '\'{val}'}),
         ('\'ba\\\'zaar\'', {'0': '\'ba\\\'zaar\'', '1': 'ba\'zaar'}),
-        # ('quote , ', {'0': 'quote , ', '1': 'quote', '2': None}),
-        # (', John Smith', {'0': ', John Smith', '1': None, '2': 'John Smith'}),
         (
             'first, second one, third',
             {
@@ -35,12 +28,7 @@ import pytest
                 '2': 'second one', '3': 'third',
             },
         ),
-        # (
-        #     'first,,third,',
-        #     {'0': 'first,,third,', '1': 'first', '2': None, '3': 'third', '4': None}
-        # ),
         ('=foo=', {'0': '=foo=', '1': '=foo='}),
-        # ('foo=bar', {'0': 'foo=bar', 'foo': 'bar'}),
         ('foo="bar"', {'0': 'foo="bar"', 'foo': 'bar'}),
         (
             'height=100,caption="",link="images/octocat.png"',
@@ -61,6 +49,20 @@ import pytest
                 'link': 'images/octocat.png',
             },
         ),
+    ),
+    # tests taken from
+    # https://github.com/asciidoctor/asciidoctor/blob/main/test/attribute_list_test.rb
+    "future": (
+        ('"ba\"zaar"', {'0': '"ba\"zaar"', '1': 'ba"zaar'}),
+        ('name=\'', {'0': 'name=\'', 'name': '\''}),
+        ('name=\'{val}', {'0': 'name=\'{val}', 'name': '\'{val}'}),
+        ('quote , ', {'0': 'quote , ', '1': 'quote', '2': None}),
+        (', John Smith', {'0': ', John Smith', '1': None, '2': 'John Smith'}),
+        # (
+        #     'first,,third,',
+        #     {'0': 'first,,third,', '1': 'first', '2': None, '3': 'third', '4': None}
+        # ),
+        # ('foo=bar', {'0': 'foo=bar', 'foo': 'bar'}),
         # ('foo=', {'0': 'foo=', 'foo': ''}),
         # ('foo=,bar=baz', {'0': 'foo=,bar=baz', 'foo': '', 'bar': 'baz'}),
         # (
@@ -112,8 +114,22 @@ import pytest
         #     },
         # ),
     )
+}
+
+@pytest.mark.parametrize(
+    "input,expected",
+    testcases["legacy"],
 )
 def test_parse_attributes(input, expected):
+    output = dict()
+    attrs.parse_attributes(input, output)
+    assert output == expected
+
+@pytest.mark.parametrize(
+    "input,expected",
+    testcases['legacy'] + testcases["future"],
+)
+def test_parse_future_attributes(enable_future_compat, input, expected):
     output = dict()
     attrs.parse_attributes(input, output)
     assert output == expected


### PR DESCRIPTION
This PR brings asciidoc-py to use similar parsing method as [asciidoctor's attribute parser](https://docs.asciidoctor.org/asciidoc/latest/attributes/positional-and-named-attributes/#attribute-list-parsing), which loosens how parsing is done so that quotes are not always required, values are trimmed, etc.

Unfortunately, there are a handful of breaking changes with the parsing so this cannot be enabled for everyone as a 10.x point release, and must wait till 11.0 to be enabled for all. The plan is to roll this feature out behind a "future compat" flag (#254) as this does break things on how they currently work, where:

1. positional arguments can occur after named arguments
2. quotes around values are no longer required in a lot of cases
3. named attribute values are always parsed as strings, instead of sometimes as integers
4. you can have "empty" positional arguments that evaluate to `None`

and I think a couple other minor things that I forget off the top of my head.